### PR TITLE
Include original traceback when unwrapping an error

### DIFF
--- a/returns/result.py
+++ b/returns/result.py
@@ -59,7 +59,10 @@ class Failure(Result[Any, _ErrorType]):
 
     def unwrap(self):
         """Raises an exception, since it does not have a value inside."""
-        raise UnwrapFailedError(self) from self._inner_value
+        if isinstance(self._inner_value, BaseException):
+            raise UnwrapFailedError(self) from self._inner_value
+
+        raise UnwrapFailedError(self)
 
     def failure(self):
         """Unwraps inner error value from failed monad."""

--- a/returns/result.py
+++ b/returns/result.py
@@ -59,7 +59,7 @@ class Failure(Result[Any, _ErrorType]):
 
     def unwrap(self):
         """Raises an exception, since it does not have a value inside."""
-        if isinstance(self._inner_value, BaseException):
+        if isinstance(self._inner_value, Exception):
             raise UnwrapFailedError(self) from self._inner_value
 
         raise UnwrapFailedError(self)

--- a/returns/result.py
+++ b/returns/result.py
@@ -59,7 +59,7 @@ class Failure(Result[Any, _ErrorType]):
 
     def unwrap(self):
         """Raises an exception, since it does not have a value inside."""
-        raise UnwrapFailedError(self)
+        raise UnwrapFailedError(self) from self._inner_value
 
     def failure(self):
         """Unwraps inner error value from failed monad."""

--- a/tests/test_result/test_result_unwrap.py
+++ b/tests/test_result/test_result_unwrap.py
@@ -18,9 +18,8 @@ def test_unwrap_failure():
 
 
 def test_unwrap_failure_with_exception():
-    """Ensures that unwrap raises UnwrapFailedError from the
-    original exception."""
-    expected_exception = ValueError("error")
+    """Ensures that unwrap raises from the original exception."""
+    expected_exception = ValueError('error')
     with pytest.raises(UnwrapFailedError) as excinfo:
         Failure(expected_exception).unwrap()
 

--- a/tests/test_result/test_result_unwrap.py
+++ b/tests/test_result/test_result_unwrap.py
@@ -15,3 +15,13 @@ def test_unwrap_failure():
     """Ensures that unwrap works for Failure monad."""
     with pytest.raises(UnwrapFailedError):
         assert Failure(5).unwrap()
+
+
+def test_unwrap_failure_with_exception():
+    """Ensures that unwrap raises UnwrapFailedError from the
+    original exception."""
+    expected_exception = ValueError("error")
+    with pytest.raises(UnwrapFailedError) as excinfo:
+        Failure(expected_exception).unwrap()
+
+    assert 'ValueError: error' in str(excinfo.getrepr())


### PR DESCRIPTION
This will allow the users to understand better where the exception came from and why it occurred.