### PR TITLE
Add `Result.{is_success, is_failure}`

### DIFF
--- a/returns/result.py
+++ b/returns/result.py
@@ -243,6 +243,32 @@ class Result(
         """
         raise NotImplementedError
 
+    def is_success(self) -> bool:
+        """
+        Returns ``True`` only if this ``Result`` is a ``Success``.
+
+        .. code:: python
+
+          >>> from returns.result import Failure, Success
+          >>> assert Success(1).is_success()
+          >>> assert not Failure(1).is_success()
+
+        """
+        raise NotImplementedError
+
+    def is_failure(self) -> bool:
+        """
+        Returns ``True`` only if this ``Result`` is a ``Failure``.
+
+        .. code:: python
+
+          >>> from returns.result import Failure, Success
+          >>> assert not Success(1).is_failure()
+          >>> assert Failure(1).is_failure()
+
+        """
+        raise NotImplementedError
+
     @classmethod
     def lift(
         cls,
@@ -385,6 +411,14 @@ class _Failure(Result[Any, _ErrorType]):
         """Returns failed value."""
         return self._inner_value
 
+    def is_success(self) -> bool:
+        """Always returns ``False``."""
+        return False
+
+    def is_failure(self) -> bool:
+        """Always returns ``True``."""
+        return True
+
 
 @final
 class _Success(Result[_ValueType, Any]):
@@ -452,6 +486,14 @@ class _Success(Result[_ValueType, Any]):
     def failure(self):
         """Raises an exception for successful container."""
         raise UnwrapFailedError(self)
+
+    def is_success(self) -> bool:
+        """Always returns ``True``."""
+        return True
+
+    def is_failure(self) -> bool:
+        """Always returns ``False``."""
+        return False
 
 
 Result.success_type = _Success

--- a/tests/test_result/test_result_base.py
+++ b/tests/test_result/test_result_base.py
@@ -24,6 +24,8 @@ def test_result_abstract_method(method_name):
 @pytest.mark.parametrize('method_name', [
     'failure',
     'unwrap',
+    'is_success',
+    'is_failure',
 ])
 def test_result_abstract_method_single(method_name):
     """Checks that Result itself contains abstract methods."""

--- a/tests/test_result/test_result_is_failure.py
+++ b/tests/test_result/test_result_is_failure.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from returns.result import Failure, Success
+
+
+def test_is_failure_on_success():
+    """Ensures that Failure check returns ``False`` for Success container."""
+    assert not Success(5).is_failure()
+
+
+def test_is_failure_on_failure():
+    """Ensures that Failure check returns ``True`` for Failure container."""
+    assert Failure(5).is_failure()

--- a/tests/test_result/test_result_is_success.py
+++ b/tests/test_result/test_result_is_success.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from returns.result import Failure, Success
+
+
+def test_is_success_on_success():
+    """Ensures that Success check returns ``True`` for Success container."""
+    assert Success(5).is_success()
+
+
+def test_is_success_on_failure():
+    """Ensures that Success check returns ``False`` for Failure container."""
+    assert not Failure(5).is_success()


### PR DESCRIPTION
Idea suggested by @sobolevn in https://github.com/dry-python/returns/pull/300#pullrequestreview-382804352.