### PR TITLE
Adds `__copy__` and `__deepcopy__` magic methods to `Immutable` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ See [0Ver](https://0ver.org/).
 - Adds typed `partial` plugin!
 - Adds `pytest` plugin with the ability to tests error handling
 - Adds `unify` point free function
+- Adds `__copy__` and `__deepcopy__` magic methods to `Immutable` class
 
 ### Bugfixes
 

--- a/returns/primitives/types.py
+++ b/returns/primitives/types.py
@@ -1,4 +1,4 @@
-from typing import Any, NoReturn
+from typing import Any, Dict, NoReturn
 
 from returns.primitives.exceptions import ImmutableStateError
 
@@ -28,6 +28,14 @@ class Immutable(object):
     See :class:`returns.primitives.container.BaseContainer` for examples.
 
     """
+
+    def __copy__(self) -> 'Immutable':
+        """Returns it self."""
+        return self
+
+    def __deepcopy__(self, memo: Dict[Any, Any]) -> 'Immutable':
+        """Returns it self."""
+        return self
 
     def __setattr__(self, attr_name: str, attr_value: Any) -> NoReturn:
         """Makes inner state of the containers immutable for modification."""

--- a/tests/test_context/test_requires_context/test_context.py
+++ b/tests/test_context/test_requires_context/test_context.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 
 from returns.context import Context, RequiresContext
@@ -24,3 +26,15 @@ def test_context_immutable():
     """Ensures that RequiresContext container supports ``.map()`` method."""
     with pytest.raises(ImmutableStateError):
         Context().abc = 1
+
+
+def test_context_immutable_copy():
+    """Ensures that Context returns it self when passed to copy function."""
+    context: Context = Context()
+    assert context is copy(context)
+
+
+def test_context_immutable_deepcopy():
+    """Ensures that Context returns it self when passed to deepcopy function."""
+    context: Context = Context()
+    assert context is deepcopy(context)

--- a/tests/test_context/test_requires_context/test_context.py
+++ b/tests/test_context/test_requires_context/test_context.py
@@ -23,7 +23,7 @@ def test_protocols(container, protocol):
 
 
 def test_context_immutable():
-    """Ensures that RequiresContext container supports ``.map()`` method."""
+    """Ensures that Context is immutable."""
     with pytest.raises(ImmutableStateError):
         Context().abc = 1
 

--- a/tests/test_context/test_requires_context_io_result/test_context_io_result.py
+++ b/tests/test_context/test_requires_context_io_result/test_context_io_result.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 
 from returns.context import ContextIOResult, RequiresContextIOResult
@@ -50,3 +52,15 @@ def test_requires_context_result_immutable():
     """Ensures that container is immutable."""
     with pytest.raises(ImmutableStateError):
         RequiresContextIOResult.from_success(1).abc = 1
+
+
+def test_requires_context_result_immutable_copy():
+    """Ensures that helper returns it self when passed to copy function."""
+    context_i_o_result: ContextIOResult = ContextIOResult()
+    assert context_i_o_result is copy(context_i_o_result)
+
+
+def test_requires_context_result_immutable_deepcopy():  # noqa: WPS118
+    """Ensures that helper returns it self when passed to deepcopy function."""
+    requires_context = RequiresContextIOResult.from_success(1)
+    assert requires_context is deepcopy(requires_context)

--- a/tests/test_context/test_requires_context_result/test_context_result.py
+++ b/tests/test_context/test_requires_context_result/test_context_result.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 
 from returns.context import ContextResult, RequiresContextResult
@@ -41,6 +43,18 @@ def test_context_result_immutable():
     """Ensures that helper is immutable."""
     with pytest.raises(ImmutableStateError):
         ContextResult().abc = 1
+
+
+def test_context_result_immutable_copy():
+    """Ensures that helper returns it self when passed to copy function."""
+    context_result: ContextResult = ContextResult()
+    assert context_result is copy(context_result)
+
+
+def test_context_result_immutable_deepcopy():
+    """Ensures that helper returns it self when passed to deepcopy function."""
+    context_result: ContextResult = ContextResult()
+    assert context_result is deepcopy(context_result)
 
 
 def test_requires_context_result_immutable():

--- a/tests/test_maybe/test_maybe_equality.py
+++ b/tests/test_maybe/test_maybe_equality.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 
 from returns.maybe import Nothing, Some, _Nothing
@@ -79,3 +81,27 @@ def test_immutability_success():
 
     with pytest.raises(AttributeError):
         Some(1).missing  # type: ignore # noqa: WPS428
+
+
+def test_success_immutable_copy():
+    """Ensures that Success returns it self when passed to copy function."""
+    some = Some(1)  # noqa: WPS110
+    assert some is copy(some)
+
+
+def test_success_immutable_deepcopy():
+    """Ensures that Success returns it self when passed to deepcopy function."""
+    some = Some(1)  # noqa: WPS110
+    assert some is deepcopy(some)
+
+
+def test_failure_immutable_copy():
+    """Ensures that Failure returns it self when passed to copy function."""
+    nothing = _Nothing()
+    assert nothing is copy(nothing)
+
+
+def test_failure_immutable_deepcopy():
+    """Ensures that Failure returns it self when passed to deepcopy function."""
+    nothing = _Nothing()
+    assert nothing is deepcopy(nothing)

--- a/tests/test_result/test_result_equality.py
+++ b/tests/test_result/test_result_equality.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 
 from returns.primitives.exceptions import ImmutableStateError
@@ -82,3 +84,27 @@ def test_immutability_success():
 
     with pytest.raises(AttributeError):
         Success(1).missing  # type: ignore # noqa: WPS428
+
+
+def test_success_immutable_copy():
+    """Ensures that Success returns it self when passed to copy function."""
+    success = Success(1)
+    assert success is copy(success)
+
+
+def test_success_immutable_deepcopy():
+    """Ensures that Success returns it self when passed to deepcopy function."""
+    success = Success(1)
+    assert success is deepcopy(success)
+
+
+def test_failure_immutable_copy():
+    """Ensures that Failure returns it self when passed to copy function."""
+    failure = Failure(0)
+    assert failure is copy(failure)
+
+
+def test_failure_immutable_deepcopy():
+    """Ensures that Failure returns it self when passed to deepcopy function."""
+    failure = Failure(0)
+    assert failure is deepcopy(failure)


### PR DESCRIPTION
The `__copy__` and `__deepcopy__` magic methods was implemented, both returning the `self` reference.

Closes #276