### PR TITLE
Add `NoDeps` type alias for `Any`

### DIFF
--- a/returns/context/__init__.py
+++ b/returns/context/__init__.py
@@ -7,6 +7,7 @@ isort:skip_file
 from returns.context.requires_context import (  # noqa: F401
     Context as Context,
     RequiresContext as RequiresContext,
+    NoDeps as NoDeps,
 )
 from returns.context.requires_context_result import (  # noqa: F401
     ContextResult as ContextResult,

--- a/returns/context/requires_context.py
+++ b/returns/context/requires_context.py
@@ -27,6 +27,9 @@ _ErrorType = TypeVar('_ErrorType')
 # Helpers:
 _FirstType = TypeVar('_FirstType')
 
+# Type Aliases:
+NoDeps = Any
+
 
 @final
 class RequiresContext(

--- a/returns/context/requires_context.py
+++ b/returns/context/requires_context.py
@@ -28,6 +28,8 @@ _ErrorType = TypeVar('_ErrorType')
 _FirstType = TypeVar('_FirstType')
 
 # Type Aliases:
+#: Sometimes ``RequiresContext`` and other similar types might be used with
+#: no explicit dependencies so we need to have this type alias for Any.
 NoDeps = Any
 
 

--- a/returns/context/requires_context.py
+++ b/returns/context/requires_context.py
@@ -70,7 +70,7 @@ class RequiresContext(
     _inner_value: Callable[['RequiresContext', _EnvType], _ReturnType]
 
     #: A convinient placeholder to call methods created by `.from_value()`:
-    empty: ClassVar[Any] = object()
+    empty: ClassVar[NoDeps] = object()
 
     def __init__(
         self, inner_value: Callable[[_EnvType], _ReturnType],

--- a/returns/context/requires_context_io_result.py
+++ b/returns/context/requires_context_io_result.py
@@ -10,6 +10,7 @@ from typing import (
 
 from typing_extensions import final
 
+from returns.context import NoDeps
 from returns.io import IO, IOFailure, IOResult, IOSuccess
 from returns.primitives.container import BaseContainer
 from returns.primitives.types import Immutable
@@ -109,7 +110,7 @@ class RequiresContextIOResult(
     ]
 
     #: A convinient placeholder to call methods created by `.from_value()`.
-    empty: ClassVar[Any] = object()
+    empty: ClassVar[NoDeps] = object()
 
     def __init__(
         self,

--- a/returns/context/requires_context_result.py
+++ b/returns/context/requires_context_result.py
@@ -10,6 +10,7 @@ from typing import (
 
 from typing_extensions import final
 
+from returns.context import NoDeps
 from returns.primitives.container import BaseContainer
 from returns.primitives.types import Immutable
 from returns.result import Failure, Result, Success
@@ -100,7 +101,7 @@ class RequiresContextResult(
     ]
 
     #: A convinient placeholder to call methods created by `.from_value()`.
-    empty: ClassVar[Any] = object()
+    empty: ClassVar[NoDeps] = object()
 
     def __init__(
         self,


### PR DESCRIPTION
The type alias was created in `returns/context/requires_context.py` and reexported in `returns/context/__init__.py` file.

The type of "empty" attribute in `RequiresContext` was changed, from:
```python
class RequiresContext:
    # code
   empty: ClassVar[Any] = object()
```
to:
```python
class RequiresContext:
    # code
    empty: ClassVar[NoDeps] = object()
```

The same modifications was made in `RequiresContextResult` and `RequiresContextIOResult` classes.

Closes #273 