### PR TITLE
Switch to logo with white outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Returns logo](https://raw.githubusercontent.com/dry-python/brand/master/logo/returns.png)](https://github.com/dry-python/returns)
+[![Returns logo](https://raw.githubusercontent.com/dry-python/brand/master/logo/returns_white-outline.png)](https://github.com/dry-python/returns)
 
 -----
 


### PR DESCRIPTION
This makes the logo stand out on dark backgrounds, too (fixes #195).

The variant became available with dry-python/brand#2.