### PR TITLE
Adds missing class doc string and `__slots__` to `_ReturnsAsserts`, `_PatchedContainer` classes

### DIFF
--- a/returns/contrib/pytest/plugin.py
+++ b/returns/contrib/pytest/plugin.py
@@ -17,6 +17,10 @@ _ERRORS_COPIERS: Final = (
 
 @final
 class _ReturnsAsserts(object):
+    """Class with helpers assertions to check containers."""
+
+    __slots__ = ()
+
     def is_error_handled(self, container) -> bool:
         """Ensures that container has its error handled in the end."""
         return getattr(container, _ERROR_FIELD, False)

--- a/returns/contrib/pytest/plugin.py
+++ b/returns/contrib/pytest/plugin.py
@@ -56,7 +56,12 @@ def _patch_error_handling(methods, patch_handler) -> None:
                 setattr(container, method, patch_handler(original))
 
 
+@final
 class _PatchedContainer(object):
+    """Class with helper methods to patched containers."""
+
+    __slots__ = ()
+
     @classmethod
     def containers_to_patch(cls) -> tuple:
         """We need this method so coverage will work correctly."""


### PR DESCRIPTION
Adds missing class doc string and `__slots__` to `_ReturnsAsserts`, `_PatchedContainer` classes!
Adds missing `@final` decorator to the `_PatchedContainer` class!

closes #415 
closes #416 