### PR TITLE
Add a helper to test traces

### DIFF
--- a/docs/pages/contrib/pytest_plugins.rst
+++ b/docs/pages/contrib/pytest_plugins.rst
@@ -73,6 +73,8 @@ created and looking for the desired function.
 
   >>> from returns.result import Result, Success, Failure
 
+  >>> returns_fixture = getfixture('returns')
+
   >>> def desired_function(arg: str) -> Result[int, str]:
   ...     if arg.isnumeric():
   ...         return Success(int(arg))
@@ -85,6 +87,9 @@ created and looking for the desired function.
   >>> def test_if_success_is_created_at_convert_function(returns):
   ...     with returns.has_trace(Success, desired_function):
   ...         Success('42').bind(desired_function)
+
+  >>> test_if_failure_is_created_at_convert_function(returns_fixture)
+  >>> test_if_success_is_created_at_convert_function(returns_fixture)
 
 Further reading
 ---------------

--- a/docs/pages/contrib/pytest_plugins.rst
+++ b/docs/pages/contrib/pytest_plugins.rst
@@ -60,6 +60,32 @@ This is how it works internally:
   It does not affect production code.
 
 
+has_trace
+~~~~~~~~~
+
+Sometimes we have to know if a container is created correctly in a specific
+point of our flow.
+
+``has_trace`` helps us to check exactly this by identifying when a container is
+created and looking for the desired function.
+
+.. code:: python
+
+  >>> from returns.result import Result, Success, Failure
+
+  >>> def desired_function(arg: str) -> Result[int, str]:
+  ...     if arg.isnumeric():
+  ...         return Success(int(arg))
+  ...     return Failure('"{0}" is not a number'.format(arg))
+
+  >>> def test_if_failure_is_created_at_convert_function(returns):
+  ...     with returns.has_trace(Failure, desired_function):
+  ...         Success('not a number').bind(desired_function)
+
+  >>> def test_if_success_is_created_at_convert_function(returns):
+  ...     with returns.has_trace(Success, desired_function):
+  ...         Success('42').bind(desired_function)
+
 Further reading
 ---------------
 

--- a/returns/contrib/pytest/plugin.py
+++ b/returns/contrib/pytest/plugin.py
@@ -3,10 +3,13 @@ import sys
 from contextlib import contextmanager
 from functools import partial, wraps
 from types import FrameType
-from typing import Any, Callable, Iterator, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterator, TypeVar
 
 import pytest
 from typing_extensions import Final, final
+
+if TYPE_CHECKING:
+    from returns.interfaces.specific.result import ResultBasedN
 
 _ERROR_FIELD: Final = '_error_handled'
 _ERROR_HANDLERS: Final = (
@@ -18,11 +21,9 @@ _ERRORS_COPIERS: Final = (
 )
 
 _FunctionType = TypeVar('_FunctionType', bound=Callable)
-# _ResultBasedType represents `Callable[[Any], ResultBasedN[Any, Any, Any]]`
-# but we cannot import `ResultBasedN` here because we're omitting this file from
-# the coverage report and `coverage.py` will exclude the class' coverage
-# information if we import it here.
-_ResultBasedType = TypeVar('_ResultBasedType', bound=Callable)
+_ResultBasedType = TypeVar(
+    '_ResultBasedType', bound=Callable[..., 'ResultBasedN'],
+)
 
 
 class _DesiredFunctionFound(RuntimeError):

--- a/returns/contrib/pytest/plugin.py
+++ b/returns/contrib/pytest/plugin.py
@@ -21,8 +21,8 @@ _ERRORS_COPIERS: Final = (
 )
 
 _FunctionType = TypeVar('_FunctionType', bound=Callable)
-_ResultBasedType = TypeVar(
-    '_ResultBasedType', bound=Callable[..., 'ResultBasedN'],
+_ResultCallableType = TypeVar(
+    '_ResultCallableType', bound=Callable[..., 'ResultBasedN'],
 )
 
 
@@ -42,7 +42,9 @@ class _ReturnsAsserts(object):
 
     @contextmanager
     def has_trace(
-        self, trace_type: _ResultBasedType, function_to_search: _FunctionType,
+        self,
+        trace_type: _ResultCallableType,
+        function_to_search: _FunctionType,
     ) -> Iterator[None]:
         old_tracer = sys.gettrace()
         sys.settrace(partial(_trace_function, trace_type, function_to_search))
@@ -90,7 +92,7 @@ def _patch_error_handling(methods, patch_handler) -> None:
 
 
 def _trace_function(
-    trace_type: _ResultBasedType,
+    trace_type: _ResultCallableType,
     function_to_search: _FunctionType,
     frame: FrameType,
     event: str,

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ per-file-ignores =
   returns/_generated/futures/*.py: WPS204, WPS433, WPS437
   # We allow a lot of durty hacks in our plugins:
   returns/contrib/mypy/*.py: S101, WPS201
-  returns/contrib/pytest/plugin.py: WPS430, WPS433, WPS437, WPS609
+  returns/contrib/pytest/plugin.py: WPS201, WPS430, WPS433, WPS437, WPS609
   # There are multiple assert's in tests:
   tests/*.py: S101, WPS204, WPS218, WPS226, WPS432, WPS436
   # Annotations:

--- a/tests/test_contrib/test_pytest/test_plugin_has_trace.py
+++ b/tests/test_contrib/test_pytest/test_plugin_has_trace.py
@@ -1,0 +1,80 @@
+import pytest
+
+from returns.io import IOFailure, IOSuccess
+from returns.result import Failure, Success
+
+
+def _create_container_function(container_type, container_value):
+    return container_type(container_value)
+
+
+def _create_container_function_intermediate(container_type, container_value):
+    return _create_container_function(
+        container_type, container_value,
+    )  # type: ignore
+
+
+@pytest.mark.parametrize('container_type', [  # noqa: WPS118
+    Success,
+    Failure,
+    IOSuccess,
+    IOFailure,
+])
+def test_has_trace_with_one_function_call_in_the_call_stack(  # noqa: WPS118
+    container_type, returns,
+):
+    """Test if our plugin will identify the container creation correctly."""
+    with returns.has_trace(container_type, _create_container_function):
+        _create_container_function(container_type, 1)  # type: ignore
+
+
+@pytest.mark.parametrize('container_type', [  # noqa: WPS118
+    Success,
+    Failure,
+    IOSuccess,
+    IOFailure,
+])
+def test_has_trace_with_two_functions_call_in_the_call_stack(  # noqa: WPS118
+    container_type, returns,
+):
+    """Test if our plugin will identify the container creation correctly."""
+    with returns.has_trace(container_type, _create_container_function):
+        _create_container_function_intermediate(
+            container_type, 1,
+        )  # type: ignore
+
+
+@pytest.mark.parametrize(('desired_container_type', 'wrong_container_type'), [  # noqa: E501, WPS118
+    (Success, Failure),
+    (Failure, Success),
+    (IOSuccess, IOFailure),
+    (IOFailure, IOSuccess),
+])
+def test_failed_has_trace_with_one_function_call_in_the_call_stack(  # noqa: E501, WPS118
+    desired_container_type, wrong_container_type, returns,
+):
+    """Test if our plugin will identify the conainter was not created."""
+    with pytest.raises(pytest.fail.Exception):  # noqa: PT012
+        with returns.has_trace(
+            desired_container_type, _create_container_function,
+        ):
+            _create_container_function(wrong_container_type, 1)  # type: ignore
+
+
+@pytest.mark.parametrize(('desired_container_type', 'wrong_container_type'), [  # noqa: E501, WPS118
+    (Success, Failure),
+    (Failure, Success),
+    (IOSuccess, IOFailure),
+    (IOFailure, IOSuccess),
+])
+def test_failed_has_trace_with_two_functions_call_in_the_call_stack(  # noqa: E501, WPS118
+    desired_container_type, wrong_container_type, returns,
+):
+    """Test if our plugin will identify the conainter was not created."""
+    with pytest.raises(pytest.fail.Exception):  # noqa: PT012
+        with returns.has_trace(
+            desired_container_type, _create_container_function,
+        ):
+            _create_container_function_intermediate(
+                wrong_container_type, 1,
+            )  # type: ignore


### PR DESCRIPTION
The final API I've suggested is like `pytest.raises`:

```python
from returns.result import Result, Success, Failure

def desired_function(arg: str) -> Result[int, str]:
    if arg.isnumeric():
        return Success(int(arg))
    return Failure('"{0}" is not a number'.format(arg))

def test_if_failure_is_created_at_convert_function(returns):
    with returns.has_trace(Failure, desired_function):
        Success('not a number').bind(desired_function)
```

### Why it's better than the initial idea when our plugin will call the function to the user?

It's better because we do not have to call the function to the user!!

---

I've heavily inspired by `pytest` implementation of `raises` but simplifying a little.

* [raises](https://github.com/pytest-dev/pytest/blob/3a060b77e81ebf990159e59cc8f8de26ad998e12/src/_pytest/python_api.py#L568)
* [RaisesContext](https://github.com/pytest-dev/pytest/blob/3a060b77e81ebf990159e59cc8f8de26ad998e12/src/_pytest/python_api.py#L720): This is the `contextmanager`

If the check fails our plugin does not broke the `pytest` flow because we're using `pytest.fail` to communicate the failure:
```text
========================================================================================================== short test summary info ===========================================================================================================
FAILED tests/test_contrib/test_pytest/test_plugin_has_trace.py::test_failed_has_trace_with_one_function_call_in_the_call_stack[Success-Failure] - Failed: No container Success was created
FAILED tests/test_contrib/test_pytest/test_plugin_has_trace.py::test_failed_has_trace_with_one_function_call_in_the_call_stack[IOSuccess-IOFailure] - Failed: No container IOSuccess was created
FAILED tests/test_contrib/test_pytest/test_plugin_has_trace.py::test_failed_has_trace_with_one_function_call_in_the_call_stack[Failure-Success] - Failed: No container Failure was created
FAILED tests/test_contrib/test_pytest/test_plugin_has_trace.py::test_failed_has_trace_with_one_function_call_in_the_call_stack[IOFailure-IOSuccess] - Failed: No container IOFailure was created
======================================================================================================== 4 failed, 12 passed in 1.18s ========================================================================================================
```

Closes #430