### PR TITLE
Adds `cond` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ See [0Ver](https://0ver.org/).
 - Changes `iterable` helper function to be `iterable_kind`,
   now it works with any `KindN`
 - Adds a helper to test traces to our `pytest` plugin
+- Adds `cond` method to `methods` package
 
 ### Bugfixes
 

--- a/docs/pages/methods.rst
+++ b/docs/pages/methods.rst
@@ -42,6 +42,33 @@ That's illustrates pretty well, why do we have both.
 Use ``internal_`` method while working in kinded context.
 Use user-facing methods when working with real types.
 
+cond
+----
+
+When we're working with ``ResultLikeN`` containers is common to write pieces of
+code like this:
+
+.. code:: python
+
+  >>> from returns.result import Success, Result, Failure
+
+  >>> def is_positive(number: int) -> Result[int, str]:
+  ...     if number >= 0:
+  ...         return Success(number)
+  ...     return Failure('Negative number')
+
+Using ``cond`` you can reduce this ``if`` pattern, see the same function above
+written using ``cond``:
+
+.. code:: python
+
+  >>> from returns.methods import cond
+
+  >>> def is_positive(number: int) -> Result[int, str]:
+  ...     return cond(Result, number >= 0, number, 'Negative number')
+
+  >>> assert is_positive(10) == Success(10)
+  >>> assert is_positive(-10) == Failure('Negative number')
 
 API Reference
 -------------
@@ -132,6 +159,12 @@ bind_context methods
 .. autofunction:: returns.methods.bind_context.internal_bind_context3
 .. autofunction:: returns.methods.bind_context.bind_context3
 .. autofunction:: returns.methods.bind_context.bind_context
+
+cond
+~~~~
+
+.. autofunction:: returns.methods.cond.internal_cond
+.. autofunction:: returns.methods.cond.cond
 
 modify_env methods
 ~~~~~~~~~~~~~~~~~~

--- a/returns/io.py
+++ b/returns/io.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from functools import wraps
 from inspect import FrameInfo
 from typing import (
@@ -320,7 +320,7 @@ class IOResult(
     Implementation
     ~~~~~~~~~~~~~~
     This class contains all the methods that can be delegated to ``Result``.
-    But, some methods are ``@abstractmethod`` which means
+    But, some methods are not implemented which means
     that we have to use special :class:`~_IOSuccess` and :class:`~_IOFailure`
     implementation details to correctly handle these callbacks.
 
@@ -420,7 +420,6 @@ class IOResult(
             )
         return container  # type: ignore
 
-    @abstractmethod
     def bind(
         self,
         function: Callable[
@@ -448,7 +447,6 @@ class IOResult(
     #: Alias for `bind_ioresult` method. Part of the `IOResultBasedN` interface.
     bind_ioresult = bind
 
-    @abstractmethod
     def bind_result(
         self,
         function: Callable[
@@ -479,7 +477,6 @@ class IOResult(
 
         """
 
-    @abstractmethod
     def bind_io(
         self,
         function: Callable[[_ValueType], IO[_NewValueType]],
@@ -542,7 +539,6 @@ class IOResult(
         """
         return self.from_result(self._inner_value.alt(function))
 
-    @abstractmethod
     def rescue(
         self,
         function: Callable[

--- a/returns/maybe.py
+++ b/returns/maybe.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from functools import wraps
 from typing import (
     Any,
@@ -60,7 +60,6 @@ class Maybe(
     #: Failure type that is used to represent the failed computation.
     failure_type: ClassVar[Type['_Nothing']]
 
-    @abstractmethod  # noqa: WPS125
     def map(  # noqa: WPS125
         self,
         function: Callable[[_ValueType], Optional[_NewValueType]],
@@ -79,7 +78,6 @@ class Maybe(
 
         """
 
-    @abstractmethod
     def apply(
         self,
         function: Kind1['Maybe', Callable[[_ValueType], _NewValueType]],
@@ -101,7 +99,6 @@ class Maybe(
 
         """
 
-    @abstractmethod
     def bind(
         self,
         function: Callable[[_ValueType], Kind1['Maybe', _NewValueType]],
@@ -135,7 +132,6 @@ class Maybe(
 
         """
 
-    @abstractmethod
     def or_else_call(
         self,
         function: Callable[[], _NewValueType],
@@ -171,7 +167,6 @@ class Maybe(
 
         """
 
-    @abstractmethod
     def unwrap(self) -> _ValueType:
         """
         Get value from successful container or raise exception for failed one.
@@ -188,7 +183,6 @@ class Maybe(
 
         """
 
-    @abstractmethod
     def failure(self) -> None:
         """
         Get failed value from failed container or raise exception from success.

--- a/returns/methods/__init__.py
+++ b/returns/methods/__init__.py
@@ -19,6 +19,7 @@ from returns.methods.bind_future_result import (
 from returns.methods.bind_io import bind_io as bind_io
 from returns.methods.bind_ioresult import bind_ioresult as bind_ioresult
 from returns.methods.bind_result import bind_result as bind_result
+from returns.methods.cond import cond as cond
 from returns.methods.map import map_ as map_
 from returns.methods.modify_env import modify_env as modify_env
 from returns.methods.modify_env import modify_env2 as modify_env2

--- a/returns/methods/cond.py
+++ b/returns/methods/cond.py
@@ -1,0 +1,45 @@
+from typing import Type, TypeVar
+
+from returns.interfaces.specific.result import ResultLikeN
+from returns.primitives.hkt import KindN, kinded
+
+_ValueType = TypeVar('_ValueType')
+_ErrorType = TypeVar('_ErrorType')
+_ThirdType = TypeVar('_ThirdType')
+
+_ResultKind = TypeVar('_ResultKind', bound=ResultLikeN)
+
+
+def internal_cond(
+    container_type: Type[_ResultKind],
+    is_success: bool,
+    success_value: _ValueType,
+    error_value: _ErrorType,
+) -> KindN[_ResultKind, _ValueType, _ErrorType, _ThirdType]:
+    """
+    Help us to reduce the boilerplate when choosing paths with ``ResultLikeN``.
+
+    .. code:: python
+
+      >>> from returns.methods import cond
+      >>> from returns.result import Failure, Result, Success
+
+      >>> def is_numeric(string: str) -> Result[str, str]:
+      ...     return cond(
+      ...         Result,
+      ...         string.isnumeric(),
+      ...         'It is a number',
+      ...         'It is not a number',
+      ...     )
+
+      >>> assert is_numeric('42') == Success('It is a number')
+      >>> assert is_numeric('non numeric') == Failure('It is not a number')
+
+    """
+    if is_success:
+        return container_type.from_value(success_value)
+    return container_type.from_failure(error_value)
+
+
+#: Kinded version of :func:`~internal_cond`, use it to infer real return type.
+cond = kinded(internal_cond)

--- a/returns/methods/cond.py
+++ b/returns/methods/cond.py
@@ -1,11 +1,10 @@
 from typing import Type, TypeVar
 
 from returns.interfaces.specific.result import ResultLikeN
-from returns.primitives.hkt import KindN, kinded
+from returns.primitives.hkt import Kind2, kinded
 
 _ValueType = TypeVar('_ValueType')
 _ErrorType = TypeVar('_ErrorType')
-_ThirdType = TypeVar('_ThirdType')
 
 _ResultKind = TypeVar('_ResultKind', bound=ResultLikeN)
 
@@ -15,7 +14,7 @@ def internal_cond(
     is_success: bool,
     success_value: _ValueType,
     error_value: _ErrorType,
-) -> KindN[_ResultKind, _ValueType, _ErrorType, _ThirdType]:
+) -> Kind2[_ResultKind, _ValueType, _ErrorType]:
     """
     Help us to reduce the boilerplate when choosing paths with ``ResultLikeN``.
 

--- a/returns/result.py
+++ b/returns/result.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from functools import wraps
 from inspect import FrameInfo
 from typing import (
@@ -70,7 +70,6 @@ class Result(
         """Returns a list with stack trace when :func:`~Failure` was called."""
         return self._trace
 
-    @abstractmethod
     def swap(self) -> 'Result[_ErrorType, _ValueType]':
         """
         Swaps value and error types.
@@ -88,7 +87,6 @@ class Result(
 
         """
 
-    @abstractmethod  # noqa: WPS125
     def map(  # noqa: WPS125
         self,
         function: Callable[[_ValueType], _NewValueType],
@@ -108,7 +106,6 @@ class Result(
 
         """
 
-    @abstractmethod
     def apply(
         self,
         container: Kind2[
@@ -135,7 +132,6 @@ class Result(
 
         """
 
-    @abstractmethod
     def bind(
         self,
         function: Callable[
@@ -197,7 +193,6 @@ class Result(
         """
         return self.bind(function)  # type: ignore
 
-    @abstractmethod
     def alt(
         self,
         function: Callable[[_ErrorType], _NewErrorType],
@@ -217,7 +212,6 @@ class Result(
 
         """
 
-    @abstractmethod
     def rescue(
         self,
         function: Callable[
@@ -242,7 +236,6 @@ class Result(
 
         """
 
-    @abstractmethod
     def value_or(
         self,
         default_value: _NewValueType,
@@ -258,7 +251,6 @@ class Result(
 
         """
 
-    @abstractmethod
     def unwrap(self) -> _ValueType:
         """
         Get value or raise exception.
@@ -275,7 +267,6 @@ class Result(
 
         """
 
-    @abstractmethod
     def failure(self) -> _ErrorType:
         """
         Get failed value or raise exception.

--- a/typesafety/test_methods/test_cond.yml
+++ b/typesafety/test_methods/test_cond.yml
@@ -28,7 +28,7 @@
     from returns.methods import cond
     from returns.context import ReaderIOResult
 
-    reveal_type(cond(ReaderIOResult, True, 1.0, False))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult*[builtins.float*, builtins.bool*, <nothing>]'
+    reveal_type(cond(ReaderIOResult, True, 1.0, False))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult*[builtins.float*, builtins.bool*, Any]'
 
 - case: cond_reader_future_result
   disable_cache: true
@@ -36,7 +36,7 @@
     from returns.methods import cond
     from returns.context import ReaderFutureResult
 
-    reveal_type(cond(ReaderFutureResult, True, 1, 1.0))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult*[builtins.int*, builtins.float*, <nothing>]'
+    reveal_type(cond(ReaderFutureResult, True, 1, 1.0))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult*[builtins.int*, builtins.float*, Any]'
 
 - case: cond_custom_type
   disable_cache: true

--- a/typesafety/test_methods/test_cond.yml
+++ b/typesafety/test_methods/test_cond.yml
@@ -1,4 +1,4 @@
-- case: cond_1
+- case: cond_result
   disable_cache: true
   main: |
     from returns.methods import cond

--- a/typesafety/test_methods/test_cond.yml
+++ b/typesafety/test_methods/test_cond.yml
@@ -1,0 +1,7 @@
+- case: cond_1
+  disable_cache: true
+  main: |
+    from returns.methods import cond
+    from returns.result import Result
+
+    reveal_type(cond(Result, True, 42, '42'))  # N: Revealed type is 'returns.result.Result*[builtins.int*, builtins.str*]'

--- a/typesafety/test_methods/test_cond.yml
+++ b/typesafety/test_methods/test_cond.yml
@@ -5,3 +5,58 @@
     from returns.result import Result
 
     reveal_type(cond(Result, True, 42, '42'))  # N: Revealed type is 'returns.result.Result*[builtins.int*, builtins.str*]'
+
+- case: cond_ioresult
+  disable_cache: true
+  main: |
+    from returns.io import IOResult
+    from returns.methods import cond
+
+    reveal_type(cond(IOResult, False, 'success', 'failure'))  # N: Revealed type is 'returns.io.IOResult*[builtins.str*, builtins.str*]'
+
+- case: cond_future_result
+  disable_cache: true
+  main: |
+    from returns.future import FutureResult
+    from returns.methods import cond
+
+    reveal_type(cond(FutureResult, False, True, False))  # N: Revealed type is 'returns.future.FutureResult*[builtins.bool*, builtins.bool*]'
+
+- case: cond_reader_ioresult
+  disable_cache: true
+  main: |
+    from returns.methods import cond
+    from returns.context import ReaderIOResult
+
+    reveal_type(cond(ReaderIOResult, True, 1.0, False))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult*[builtins.float*, builtins.bool*, <nothing>]'
+
+- case: cond_reader_future_result
+  disable_cache: true
+  main: |
+    from returns.methods import cond
+    from returns.context import ReaderFutureResult
+
+    reveal_type(cond(ReaderFutureResult, True, 1, 1.0))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult*[builtins.int*, builtins.float*, <nothing>]'
+
+- case: cond_custom_type
+  disable_cache: true
+  main: |
+    from typing import TypeVar
+
+    from returns.interfaces.specific.result import ResultLike2
+    from returns.methods import cond
+    from returns.primitives.hkt import SupportsKind2
+
+    ValueType = TypeVar('ValueType')
+    ErrorType = TypeVar('ErrorType')
+
+    class MyOwn(
+        SupportsKind2['MyOwn', ValueType, ErrorType],
+        ResultLike2[ValueType, ErrorType]
+    ):
+        ...
+
+    reveal_type(cond(MyOwn, True, 'test', 1.0))
+  out: |
+    main:16: error: Only concrete class can be given where "Type[MyOwn[Any, Any]]" is expected
+    main:16: note: Revealed type is 'main.MyOwn*[builtins.str*, builtins.float*]'


### PR DESCRIPTION
Working code example:
```python
>>> from returns.methods import cond
>>> from returns.result import Failure, Result, Success

>>> def is_numeric(string: str) -> Result[str, str]:
...     return cond(
...         Result,
...         string.isnumeric(),
...         'It is a number',
...         'It is not a number',
...     )

>>> assert is_numeric('42') == Success('It is a number')
>>> assert is_numeric('non numeric') == Failure('It is not a number')
```

Closes #437 