### PR TITLE
Adds `unify` HKT method and pointfree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ See [0Ver](https://0ver.org/).
 - Adds `cond` method to `methods` package
 - Adds `cond` function to `pointfree` package
 - Adds `compose_result` HKT method and pointfree function
+- Adds `unify` HKT method and pointfree function
 
 - Adds `collect_trace` helper function for better development experience
 - Adds `hypothesis` intergration and pre-defined "monad laws as values"

--- a/docs/pages/methods.rst
+++ b/docs/pages/methods.rst
@@ -186,3 +186,9 @@ swap
 
 .. autofunction:: returns.methods.swap.internal_swap
 .. autofunction:: returns.methods.swap.swap
+
+unify
+~~~~~
+
+.. autofunction:: returns.methods.unify.internal_unify
+.. autofunction:: returns.methods.unify.unify

--- a/docs/pages/pointfree.rst
+++ b/docs/pages/pointfree.rst
@@ -297,4 +297,6 @@ API Reference
 
 .. autofunction:: returns.pointfree.rescue
 
+.. autofunction:: returns.pointfree.unify
+
 .. autofunction:: returns.pointfree.apply

--- a/returns/methods/__init__.py
+++ b/returns/methods/__init__.py
@@ -27,3 +27,4 @@ from returns.methods.modify_env import modify_env2 as modify_env2
 from returns.methods.modify_env import modify_env3 as modify_env3
 from returns.methods.rescue import rescue as rescue
 from returns.methods.swap import swap as swap
+from returns.methods.unify import unify as unify

--- a/returns/methods/unify.py
+++ b/returns/methods/unify.py
@@ -1,0 +1,47 @@
+from typing import Callable, TypeVar, Union
+
+from returns.interfaces.specific.result import ResultLikeN
+from returns.primitives.hkt import Kind2, kinded
+
+_ValueType = TypeVar('_ValueType')
+_NewValueType = TypeVar('_NewValueType')
+_ErrorType = TypeVar('_ErrorType')
+_NewErrorType = TypeVar('_NewErrorType')
+
+_ResultLikeKind = TypeVar('_ResultLikeKind', bound=ResultLikeN)
+
+
+def internal_unify(
+    container: Kind2[_ResultLikeKind, _ValueType, _ErrorType],
+    function: Callable[
+        [_ValueType], Kind2[_ResultLikeKind, _NewValueType, _NewErrorType],
+    ],
+) -> Kind2[_ResultLikeKind, _NewValueType, Union[_ErrorType, _NewErrorType]]:
+    """
+    Composes successful container with a function that returns a container.
+
+    Similar to :func:`~returns.methods.bind.bind` but has different type.
+    It returns ``Result[ValueType, Union[OldErrorType, NewErrorType]]``
+    instead of ``Result[ValueType, OldErrorType]``.
+
+    So, it can be more useful in some situations.
+    Probably with specific exceptions.
+
+    .. code:: python
+
+      >>> from returns.methods import cond, unify
+      >>> from returns.result import Result, Success, Failure
+
+      >>> def bindable(arg: int) -> Result[int, int]:
+      ...     return cond(Result, arg % 2 == 0, arg + 1, arg - 1)
+
+      >>> assert unify(Success(2), bindable) == Success(3)
+      >>> assert unify(Success(1), bindable) == Failure(0)
+      >>> assert unify(Failure(42), bindable) == Failure(42)
+
+    """
+    return container.bind(function)  # type: ignore
+
+
+#: Kinded version of :func:`~internal_unify`, use it to infer real return type.
+unify = kinded(internal_unify)

--- a/returns/pointfree/__init__.py
+++ b/returns/pointfree/__init__.py
@@ -26,3 +26,4 @@ from returns.pointfree.modify_env import modify_env as modify_env
 from returns.pointfree.modify_env import modify_env2 as modify_env2
 from returns.pointfree.modify_env import modify_env3 as modify_env3
 from returns.pointfree.rescue import rescue as rescue
+from returns.pointfree.unify import unify as unify

--- a/returns/pointfree/unify.py
+++ b/returns/pointfree/unify.py
@@ -1,0 +1,56 @@
+from typing import Callable, TypeVar, Union
+
+from returns.interfaces.specific.result import ResultLikeN
+from returns.methods.unify import internal_unify
+from returns.primitives.hkt import Kind2, Kinded, kinded
+
+_ValueType = TypeVar('_ValueType')
+_NewValueType = TypeVar('_NewValueType')
+_ErrorType = TypeVar('_ErrorType')
+_NewErrorType = TypeVar('_NewErrorType')
+
+_ResultLikeKind = TypeVar('_ResultLikeKind', bound=ResultLikeN)
+
+
+def unify(  # noqa: WPS234
+    function: Callable[
+        [_ValueType], Kind2[_ResultLikeKind, _NewValueType, _NewErrorType],
+    ],
+) -> Kinded[
+    Callable[
+        [Kind2[_ResultLikeKind, _ValueType, _ErrorType]],
+        Kind2[_ResultLikeKind, _NewValueType, Union[_ErrorType, _NewErrorType]],
+    ]
+]:
+    """
+    Composes successful container with a function that returns a container.
+
+    Similar to :func:`~returns.pointfree.bind` but has different type.
+    It returns ``Result[ValueType, Union[OldErrorType, NewErrorType]]``
+    instead of ``Result[ValueType, OldErrorType]``.
+
+    So, it can be more useful in some situations.
+    Probably with specific exceptions.
+
+    .. code:: python
+
+      >>> from returns.methods import cond
+      >>> from returns.pointfree import unify
+      >>> from returns.result import Result, Success, Failure
+
+      >>> def bindable(arg: int) -> Result[int, int]:
+      ...     return cond(Result, arg % 2 == 0, arg + 1, arg - 1)
+
+      >>> assert unify(bindable)(Success(2)) == Success(3)
+      >>> assert unify(bindable)(Success(1)) == Failure(0)
+      >>> assert unify(bindable)(Failure(42)) == Failure(42)
+
+    """
+    @kinded
+    def factory(
+        container: Kind2[_ResultLikeKind, _ValueType, _ErrorType],
+    ) -> Kind2[
+        _ResultLikeKind, _NewValueType, Union[_ErrorType, _NewErrorType],
+    ]:
+        return internal_unify(container, function)
+    return factory

--- a/typesafety/test_methods/test_unify.yml
+++ b/typesafety/test_methods/test_unify.yml
@@ -1,0 +1,83 @@
+- case: unify_result
+  disable_cache: true
+  main: |
+    from returns.methods import unify
+    from returns.result import Result
+
+    def test(arg: str) -> Result[str, ValueError]:
+        ...
+
+    x: Result[str, AssertionError]
+    reveal_type(unify(x, test))  # N: Revealed type is 'returns.result.Result[builtins.str*, Union[builtins.AssertionError, builtins.ValueError*]]'
+
+- case: unify_ioresult
+  disable_cache: true
+  main: |
+    from returns.io import IOResult
+    from returns.methods import unify
+
+    def test(arg: float) -> IOResult[str, str]:
+        ...
+
+    x: IOResult[float, bool]
+    reveal_type(unify(x, test))  # N: Revealed type is 'returns.io.IOResult[builtins.str*, Union[builtins.bool, builtins.str*]]'
+
+- case: unify_future_result
+  disable_cache: true
+  main: |
+    from returns.future import FutureResult
+    from returns.methods import unify
+
+    def test(arg: bool) -> FutureResult[bool, str]:
+        ...
+
+    x: FutureResult[bool, Exception]
+    reveal_type(unify(x, test))  # N: Revealed type is 'returns.future.FutureResult[builtins.bool*, Union[builtins.Exception, builtins.str*]]'
+
+- case: unify_reader_ioresult
+  disable_cache: true
+  main: |
+    from returns.methods import unify
+    from returns.context import ReaderIOResult
+
+    def test(arg: float) -> ReaderIOResult[bool, str, float]:
+        ...
+
+    x: ReaderIOResult[float, int, float]
+    reveal_type(unify(x, test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, Union[builtins.int, builtins.str*], Any]'
+
+- case: unify_reader_future_result
+  disable_cache: true
+  main: |
+    from returns.methods import unify
+    from returns.context import ReaderFutureResult, NoDeps
+
+    def test(arg: int) -> ReaderFutureResult[int, float, bool]:
+        ...
+
+    x: ReaderFutureResult[int, str, NoDeps]
+    reveal_type(unify(x, test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, Union[builtins.str, builtins.float*], Any]'
+
+- case: unify_custom_type
+  disable_cache: true
+  main: |
+    from typing import TypeVar
+
+    from returns.interfaces.specific.result import ResultLike2
+    from returns.methods import unify
+    from returns.primitives.hkt import SupportsKind2
+
+    ValueType = TypeVar('ValueType')
+    ErrorType = TypeVar('ErrorType')
+
+    class MyOwn(
+        SupportsKind2['MyOwn', ValueType, ErrorType],
+        ResultLike2[ValueType, ErrorType]
+    ):
+        ...
+
+    def test(arg: str) -> MyOwn[str, bool]:
+        ...
+
+    x: MyOwn[str, Exception]
+    reveal_type(unify(x, test))  # N: Revealed type is 'main.MyOwn[builtins.str*, Union[builtins.Exception, builtins.bool*]]'

--- a/typesafety/test_pointfree/test_unify.yml
+++ b/typesafety/test_pointfree/test_unify.yml
@@ -1,0 +1,83 @@
+- case: unify_result
+  disable_cache: true
+  main: |
+    from returns.pointfree import unify
+    from returns.result import Result
+
+    def test(arg: str) -> Result[str, int]:
+        ...
+
+    x: Result[str, AssertionError]
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.str, Union[builtins.AssertionError*, builtins.int]]'
+
+- case: unify_ioresult
+  disable_cache: true
+  main: |
+    from returns.io import IOResult
+    from returns.pointfree import unify
+
+    def test(arg: float) -> IOResult[str, bytes]:
+        ...
+
+    x: IOResult[float, bool]
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.str, Union[builtins.bool*, builtins.bytes]]'
+
+- case: unify_future_result
+  disable_cache: true
+  main: |
+    from returns.future import FutureResult
+    from returns.pointfree import unify
+
+    def test(arg: bool) -> FutureResult[bool, str]:
+        ...
+
+    x: FutureResult[bool, float]
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.bool, Union[builtins.float*, builtins.str]]'
+
+- case: unify_reader_ioresult
+  disable_cache: true
+  main: |
+    from returns.pointfree import unify
+    from returns.context import ReaderIOResult
+
+    def test(arg: float) -> ReaderIOResult[bool, str, float]:
+        ...
+
+    x: ReaderIOResult[float, Exception, float]
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool, Union[builtins.Exception*, builtins.str], Any]'
+
+- case: unify_reader_future_result
+  disable_cache: true
+  main: |
+    from returns.pointfree import unify
+    from returns.context import ReaderFutureResult, NoDeps
+
+    def test(arg: int) -> ReaderFutureResult[int, bool, bool]:
+        ...
+
+    x: ReaderFutureResult[int, str, NoDeps]
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str*, builtins.bool], Any]'
+
+- case: unify_custom_type
+  disable_cache: true
+  main: |
+    from typing import TypeVar
+
+    from returns.interfaces.specific.result import ResultLike2
+    from returns.pointfree import unify
+    from returns.primitives.hkt import SupportsKind2
+
+    ValueType = TypeVar('ValueType')
+    ErrorType = TypeVar('ErrorType')
+
+    class MyOwn(
+        SupportsKind2['MyOwn', ValueType, ErrorType],
+        ResultLike2[ValueType, ErrorType]
+    ):
+        ...
+
+    def test(arg: str) -> MyOwn[str, bool]:
+        ...
+
+    x: MyOwn[str, ValueError]
+    reveal_type(unify(test)(x))  # N: Revealed type is 'main.MyOwn[builtins.str, Union[builtins.ValueError*, builtins.bool]]'


### PR DESCRIPTION
# I have added `unify` HKT method and pointfree

I've used the same docstring description then `Result.unify(...)`, I think it's better to keep our docstrings the same to prevent possible misunderstandings between implementations (e.g. `unify` HKT method, pointfree and "normal" method)

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #511 
