### PR TITLE
docs: Fix simple typo, convinient -> convenient

### DIFF
--- a/returns/context/requires_context.py
+++ b/returns/context/requires_context.py
@@ -89,7 +89,7 @@ class RequiresContext(
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.
     _inner_value: Callable[['RequiresContext', _EnvType], _ReturnType]
 
-    #: A convinient placeholder to call methods created by `.from_value()`:
+    #: A convenient placeholder to call methods created by `.from_value()`:
     empty: ClassVar[NoDeps] = object()
 
     def __init__(

--- a/returns/context/requires_context_future_result.py
+++ b/returns/context/requires_context_future_result.py
@@ -113,7 +113,7 @@ class RequiresContextFutureResult(
         FutureResult[_ValueType, _ErrorType],
     ]
 
-    #: A convinient placeholder to call methods created by `.from_value()`.
+    #: A convenient placeholder to call methods created by `.from_value()`.
     empty: ClassVar[NoDeps] = object()
 
     def __init__(

--- a/returns/context/requires_context_ioresult.py
+++ b/returns/context/requires_context_ioresult.py
@@ -119,7 +119,7 @@ class RequiresContextIOResult(
         IOResult[_ValueType, _ErrorType],
     ]
 
-    #: A convinient placeholder to call methods created by `.from_value()`.
+    #: A convenient placeholder to call methods created by `.from_value()`.
     empty: ClassVar[NoDeps] = object()
 
     def __init__(

--- a/returns/context/requires_context_result.py
+++ b/returns/context/requires_context_result.py
@@ -108,7 +108,7 @@ class RequiresContextResult(
         Result[_ValueType, _ErrorType],
     ]
 
-    #: A convinient placeholder to call methods created by `.from_value()`.
+    #: A convenient placeholder to call methods created by `.from_value()`.
     empty: ClassVar[NoDeps] = object()
 
     def __init__(


### PR DESCRIPTION
There is a small typo in returns/context/requires_context.py, returns/context/requires_context_future_result.py, returns/context/requires_context_ioresult.py, returns/context/requires_context_result.py.

Should read `convenient` rather than `convinient`.

