### PR TITLE
Active `fail_on_warning` RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+python:
+  version: 3.7
+  install:
+    - docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+formats: all

--- a/docs/pages/railway.rst
+++ b/docs/pages/railway.rst
@@ -144,6 +144,7 @@ inner state of containers into a regular types:
   >>> assert Some(0).unwrap() == 0
 
 .. code:: pycon
+  :force:
 
   >>> Failure(1).unwrap()
   Traceback (most recent call last):
@@ -160,6 +161,7 @@ use :func:`.failure <returns.interfaces.unwrappable.Unwrapable.failure>`
 to unwrap the failed state:
 
 .. code:: pycon
+  :force:
 
   >>> assert Failure(1).failure() == 1
   >>> Success(1).failure()

--- a/returns/context/requires_context.py
+++ b/returns/context/requires_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -87,7 +89,7 @@ class RequiresContext(
     """
 
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.
-    _inner_value: Callable[['RequiresContext', _EnvType], _ReturnType]
+    _inner_value: Callable[[RequiresContext, _EnvType], _ReturnType]
 
     #: A convenient placeholder to call methods created by `.from_value()`:
     empty: ClassVar[NoDeps] = object()
@@ -136,7 +138,7 @@ class RequiresContext(
 
     def map(  # noqa: WPS125
         self, function: Callable[[_ReturnType], _NewReturnType],
-    ) -> 'RequiresContext[_NewReturnType, _EnvType]':
+    ) -> RequiresContext[_NewReturnType, _EnvType]:
         """
         Allows to compose functions inside the wrapped container.
 
@@ -164,7 +166,7 @@ class RequiresContext(
             Callable[[_ReturnType], _NewReturnType],
             _EnvType,
         ],
-    ) -> 'RequiresContext[_NewReturnType, _EnvType]':
+    ) -> RequiresContext[_NewReturnType, _EnvType]:
         """
         Calls a wrapped function in a container on this container.
 
@@ -186,7 +188,7 @@ class RequiresContext(
             [_ReturnType],
             Kind2['RequiresContext', _NewReturnType, _EnvType],
         ],
-    ) -> 'RequiresContext[_NewReturnType, _EnvType]':
+    ) -> RequiresContext[_NewReturnType, _EnvType]:
         """
         Composes a container with a function returning another container.
 
@@ -221,7 +223,7 @@ class RequiresContext(
     def modify_env(
         self,
         function: Callable[[_NewEnvType], _EnvType],
-    ) -> 'RequiresContext[_ReturnType, _NewEnvType]':
+    ) -> RequiresContext[_ReturnType, _NewEnvType]:
         """
         Allows to modify the environment type.
 
@@ -238,7 +240,7 @@ class RequiresContext(
         return RequiresContext(lambda deps: self(function(deps)))
 
     @classmethod
-    def ask(cls) -> 'RequiresContext[_EnvType, _EnvType]':
+    def ask(cls) -> RequiresContext[_EnvType, _EnvType]:
         """
         Get current context to use the dependencies.
 
@@ -316,13 +318,13 @@ class RequiresContext(
         See also:
             https://dev.to/gcanti/getting-started-with-fp-ts-reader-1ie5
 
-        """
+        """  # noqa: F811
         return RequiresContext(identity)
 
     @classmethod
     def from_value(
         cls, inner_value: _FirstType,
-    ) -> 'RequiresContext[_FirstType, NoDeps]':
+    ) -> RequiresContext[_FirstType, NoDeps]:
         """
         Used to return some specific value from the container.
 
@@ -343,8 +345,8 @@ class RequiresContext(
 
     @classmethod
     def from_context(
-        cls, inner_value: 'RequiresContext[_NewReturnType, _NewEnvType]',
-    ) -> 'RequiresContext[_NewReturnType, _NewEnvType]':
+        cls, inner_value: RequiresContext[_NewReturnType, _NewEnvType],
+    ) -> RequiresContext[_NewReturnType, _NewEnvType]:
         """
         Used to create new containers from existing ones.
 
@@ -363,10 +365,10 @@ class RequiresContext(
     def from_iterable(
         cls,
         inner_value: Iterable[
-            Kind2['RequiresContext', _NewReturnType, _NewEnvType],
+            Kind2[RequiresContext, _NewReturnType, _NewEnvType],
         ],
         strategy: Type[BaseIterableStrategyN] = FailFast,
-    ) -> 'RequiresContext[Sequence[_NewReturnType], _NewEnvType]':
+    ) -> RequiresContext[Sequence[_NewReturnType], _NewEnvType]:
         """
         Transforms an iterable of ``RequiresContext`` containers.
 
@@ -388,7 +390,7 @@ class RequiresContext(
     def from_requires_context_result(
         cls,
         inner_value: 'RequiresContextResult[_ValueType, _ErrorType, _EnvType]',
-    ) -> 'RequiresContext[Result[_ValueType, _ErrorType], _EnvType]':
+    ) -> RequiresContext[Result[_ValueType, _ErrorType], _EnvType]:
         """
         Typecasts ``RequiresContextResult`` to ``RequiresContext`` instance.
 
@@ -414,7 +416,7 @@ class RequiresContext(
         cls,
         inner_value:
             'RequiresContextIOResult[_ValueType, _ErrorType, _EnvType]',
-    ) -> 'RequiresContext[IOResult[_ValueType, _ErrorType], _EnvType]':
+    ) -> RequiresContext[IOResult[_ValueType, _ErrorType], _EnvType]:
         """
         Typecasts ``RequiresContextIOResult`` to ``RequiresContext`` instance.
 
@@ -440,7 +442,7 @@ class RequiresContext(
         cls,
         inner_value:
             'RequiresContextFutureResult[_ValueType, _ErrorType, _EnvType]',
-    ) -> 'RequiresContext[FutureResult[_ValueType, _ErrorType], _EnvType]':
+    ) -> RequiresContext[FutureResult[_ValueType, _ErrorType], _EnvType]:
         """
         Typecasts ``RequiresContextIOResult`` to ``RequiresContext`` instance.
 

--- a/returns/context/requires_context_future_result.py
+++ b/returns/context/requires_context_future_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -109,7 +111,7 @@ class RequiresContextFutureResult(
     #: is just a function that returns `FutureResult`.
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.
     _inner_value: Callable[
-        ['RequiresContextFutureResult', _EnvType],
+        [RequiresContextFutureResult, _EnvType],
         FutureResult[_ValueType, _ErrorType],
     ]
 
@@ -172,7 +174,7 @@ class RequiresContextFutureResult(
 
     def swap(
         self,
-    ) -> 'RequiresContextFutureResult[_ErrorType, _ValueType, _EnvType]':
+    ) -> RequiresContextFutureResult[_ErrorType, _ValueType, _EnvType]:
         """
         Swaps value and error types.
 
@@ -199,7 +201,7 @@ class RequiresContextFutureResult(
     def map(  # noqa: WPS125
         self,
         function: Callable[[_ValueType], _NewValueType],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes successful container with a pure function.
 
@@ -225,12 +227,12 @@ class RequiresContextFutureResult(
     def apply(
         self,
         container: Kind3[
-            'RequiresContextFutureResult',
+            RequiresContextFutureResult,
             Callable[[_ValueType], _NewValueType],
             _ErrorType,
             _EnvType,
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Calls a wrapped function in a container on this container.
 
@@ -267,13 +269,13 @@ class RequiresContextFutureResult(
         function: Callable[
             [_ValueType],
             Kind3[
-                'RequiresContextFutureResult',
+                RequiresContextFutureResult,
                 _NewValueType,
                 _ErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes this container with a function returning the same type.
 
@@ -320,14 +322,14 @@ class RequiresContextFutureResult(
             [_ValueType],
             Awaitable[
                 Kind3[
-                    'RequiresContextFutureResult',
+                    RequiresContextFutureResult,
                     _NewValueType,
                     _ErrorType,
                     _EnvType,
                 ],
             ],
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes this container with a async function returning the same type.
 
@@ -368,8 +370,8 @@ class RequiresContextFutureResult(
 
     def bind_awaitable(
         self,
-        function: Callable[[_ValueType], 'Awaitable[_NewValueType]'],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+        function: Callable[[_ValueType], Awaitable[_NewValueType]],
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Allows to compose a container and a regular ``async`` function.
 
@@ -407,8 +409,8 @@ class RequiresContextFutureResult(
 
     def bind_result(
         self,
-        function: Callable[[_ValueType], 'Result[_NewValueType, _ErrorType]'],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+        function: Callable[[_ValueType], Result[_NewValueType, _ErrorType]],
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``Result`` returning function to the current container.
 
@@ -447,7 +449,7 @@ class RequiresContextFutureResult(
             [_ValueType],
             'RequiresContext[_NewValueType, _EnvType]',
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``RequiresContext`` returning function to current container.
 
@@ -487,7 +489,7 @@ class RequiresContextFutureResult(
             [_ValueType],
             'RequiresContextResult[_NewValueType, _ErrorType, _EnvType]',
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``RequiresContextResult`` returning function to the current one.
 
@@ -530,7 +532,7 @@ class RequiresContextFutureResult(
             [_ValueType],
             'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]',
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``RequiresContextIOResult`` returning function to the current one.
 
@@ -569,7 +571,7 @@ class RequiresContextFutureResult(
     def bind_io(
         self,
         function: Callable[[_ValueType], IO[_NewValueType]],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``IO`` returning function to the current container.
 
@@ -600,7 +602,7 @@ class RequiresContextFutureResult(
     def bind_ioresult(
         self,
         function: Callable[[_ValueType], IOResult[_NewValueType, _ErrorType]],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``IOResult`` returning function to the current container.
 
@@ -635,7 +637,7 @@ class RequiresContextFutureResult(
     def bind_future(
         self,
         function: Callable[[_ValueType], Future[_NewValueType]],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``Future`` returning function to the current container.
 
@@ -673,7 +675,7 @@ class RequiresContextFutureResult(
             [_ValueType],
             FutureResult[_NewValueType, _ErrorType],
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``FutureResult`` returning function to the current container.
 
@@ -708,7 +710,7 @@ class RequiresContextFutureResult(
     def bind_async_future(
         self,
         function: Callable[[_ValueType], Awaitable[Future[_NewValueType]]],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``Future`` returning async function to the current container.
 
@@ -746,7 +748,7 @@ class RequiresContextFutureResult(
             [_ValueType],
             Awaitable[FutureResult[_NewValueType, _ErrorType]],
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Bind ``FutureResult`` returning async function to the current container.
 
@@ -782,7 +784,7 @@ class RequiresContextFutureResult(
 
     def alt(
         self, function: Callable[[_ErrorType], _NewErrorType],
-    ) -> 'RequiresContextFutureResult[_ValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_ValueType, _NewErrorType, _EnvType]:
         """
         Composes failed container with a pure function.
 
@@ -816,13 +818,13 @@ class RequiresContextFutureResult(
         function: Callable[
             [_ErrorType],
             Kind3[
-                'RequiresContextFutureResult',
+                RequiresContextFutureResult,
                 _ValueType,
                 _NewErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextFutureResult[_ValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_ValueType, _NewErrorType, _EnvType]:
         """
         Composes this container with a function returning the same type.
 
@@ -866,13 +868,13 @@ class RequiresContextFutureResult(
         function: Callable[
             [Result[_ValueType, _ErrorType]],
             Kind3[
-                'RequiresContextFutureResult',
+                RequiresContextFutureResult,
                 _NewValueType,
                 _ErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes inner ``Result`` with ``ReaderFutureResult`` returning func.
 
@@ -914,7 +916,7 @@ class RequiresContextFutureResult(
     def modify_env(
         self,
         function: Callable[[_NewEnvType], _EnvType],
-    ) -> 'RequiresContextFutureResult[_ValueType, _ErrorType, _NewEnvType]':
+    ) -> RequiresContextFutureResult[_ValueType, _ErrorType, _NewEnvType]:
         """
         Allows to modify the environment type.
 
@@ -939,7 +941,7 @@ class RequiresContextFutureResult(
     @classmethod
     def ask(
         cls,
-    ) -> 'RequiresContextFutureResult[_EnvType, _ErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_EnvType, _ErrorType, _EnvType]:
         """
         Is used to get the current dependencies inside the call stack.
 
@@ -970,7 +972,7 @@ class RequiresContextFutureResult(
     @classmethod
     def from_result(
         cls, inner_value: Result[_NewValueType, _NewErrorType],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _NewErrorType, NoDeps]':
+    ) -> RequiresContextFutureResult[_NewValueType, _NewErrorType, NoDeps]:
         """
         Creates new container with ``Result`` as a unit value.
 
@@ -1000,7 +1002,7 @@ class RequiresContextFutureResult(
     def from_io(
         cls,
         inner_value: IO[_NewValueType],
-    ) -> 'RequiresContextFutureResult[_NewValueType, Any, NoDeps]':
+    ) -> RequiresContextFutureResult[_NewValueType, Any, NoDeps]:
         """
         Creates new container from successful ``IO`` value.
 
@@ -1024,7 +1026,7 @@ class RequiresContextFutureResult(
     def from_failed_io(
         cls,
         inner_value: IO[_NewErrorType],
-    ) -> 'RequiresContextFutureResult[Any, _NewErrorType, NoDeps]':
+    ) -> RequiresContextFutureResult[Any, _NewErrorType, NoDeps]:
         """
         Creates a new container from failed ``IO`` value.
 
@@ -1047,7 +1049,7 @@ class RequiresContextFutureResult(
     @classmethod
     def from_ioresult(
         cls, inner_value: IOResult[_NewValueType, _NewErrorType],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _NewErrorType, NoDeps]':
+    ) -> RequiresContextFutureResult[_NewValueType, _NewErrorType, NoDeps]:
         """
         Creates new container with ``IOResult`` as a unit value.
 
@@ -1076,7 +1078,7 @@ class RequiresContextFutureResult(
     def from_future(
         cls,
         inner_value: Future[_NewValueType],
-    ) -> 'RequiresContextFutureResult[_NewValueType, Any, NoDeps]':
+    ) -> RequiresContextFutureResult[_NewValueType, Any, NoDeps]:
         """
         Creates new container with successful ``Future`` as a unit value.
 
@@ -1101,7 +1103,7 @@ class RequiresContextFutureResult(
     def from_failed_future(
         cls,
         inner_value: Future[_NewErrorType],
-    ) -> 'RequiresContextFutureResult[Any, _NewErrorType, NoDeps]':
+    ) -> RequiresContextFutureResult[Any, _NewErrorType, NoDeps]:
         """
         Creates new container with failed ``Future`` as a unit value.
 
@@ -1128,8 +1130,8 @@ class RequiresContextFutureResult(
     def from_future_result_context(
         cls,
         inner_value:
-            'ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType]',
-    ) -> 'ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType]':
+            ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType],
+    ) -> ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType]:
         """
         Creates new container with ``ReaderFutureResult`` as a unit value.
 
@@ -1160,7 +1162,7 @@ class RequiresContextFutureResult(
     def from_future_result(
         cls,
         inner_value: FutureResult[_NewValueType, _NewErrorType],
-    ) -> 'RequiresContextFutureResult[_NewValueType, _NewErrorType, NoDeps]':
+    ) -> RequiresContextFutureResult[_NewValueType, _NewErrorType, NoDeps]:
         """
         Creates new container with ``FutureResult`` as a unit value.
 
@@ -1193,7 +1195,7 @@ class RequiresContextFutureResult(
         cls,
         inner_value: 'RequiresContext['
             'FutureResult[_NewValueType, _NewErrorType], _EnvType]',
-    ) -> 'RequiresContextFutureResult[_NewValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, _NewErrorType, _EnvType]:
         """
         You might end up with ``RequiresContext[FutureResult]`` as a value.
 
@@ -1229,7 +1231,7 @@ class RequiresContextFutureResult(
     @classmethod
     def from_context(
         cls, inner_value: 'RequiresContext[_NewValueType, _NewEnvType]',
-    ) -> 'RequiresContextFutureResult[_NewValueType, Any, _NewEnvType]':
+    ) -> RequiresContextFutureResult[_NewValueType, Any, _NewEnvType]:
         """
         Creates new container from ``RequiresContext`` as a success unit.
 
@@ -1254,7 +1256,7 @@ class RequiresContextFutureResult(
     @classmethod
     def from_failed_context(
         cls, inner_value: 'RequiresContext[_NewValueType, _NewEnvType]',
-    ) -> 'RequiresContextFutureResult[Any, _NewValueType, _NewEnvType]':
+    ) -> RequiresContextFutureResult[Any, _NewValueType, _NewEnvType]:
         """
         Creates new container from ``RequiresContext`` as a failure unit.
 
@@ -1281,7 +1283,7 @@ class RequiresContextFutureResult(
         cls,
         inner_value:
             'RequiresContextResult[_NewValueType, _NewErrorType, _NewEnvType]',
-    ) -> 'ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType]':
+    ) -> ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType]:
         """
         Creates new container from ``RequiresContextResult`` as a unit value.
 
@@ -1315,7 +1317,7 @@ class RequiresContextFutureResult(
         cls,
         inner_value:
             'ReaderIOResult[_NewValueType, _NewErrorType, _NewEnvType]',
-    ) -> 'ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType]':
+    ) -> ReaderFutureResult[_NewValueType, _NewErrorType, _NewEnvType]:
         """
         Creates new container from ``RequiresContextIOResult`` as a unit value.
 
@@ -1347,7 +1349,7 @@ class RequiresContextFutureResult(
     @classmethod
     def from_value(
         cls, inner_value: _FirstType,
-    ) -> 'RequiresContextFutureResult[_FirstType, Any, NoDeps]':
+    ) -> RequiresContextFutureResult[_FirstType, Any, NoDeps]:
         """
         Creates new container with successful ``FutureResult`` as a unit value.
 
@@ -1369,7 +1371,7 @@ class RequiresContextFutureResult(
     @classmethod
     def from_failure(
         cls, inner_value: _FirstType,
-    ) -> 'RequiresContextFutureResult[Any, _FirstType, NoDeps]':
+    ) -> RequiresContextFutureResult[Any, _FirstType, NoDeps]:
         """
         Creates new container with failed ``FutureResult`` as a unit value.
 
@@ -1393,14 +1395,14 @@ class RequiresContextFutureResult(
         cls,
         inner_value: Iterable[
             Kind3[
-                'RequiresContextFutureResult',
+                RequiresContextFutureResult,
                 _FirstType,
                 _NewErrorType,
                 _NewEnvType,
             ],
         ],
         strategy: Type[BaseIterableStrategyN] = FailFast,
-    ) -> 'ReaderFutureResult[Sequence[_FirstType], _NewErrorType, _NewEnvType]':
+    ) -> ReaderFutureResult[Sequence[_FirstType], _NewErrorType, _NewEnvType]:
         """
         Transforms an iterable of ``RequiresContextFutureResult`` containers.
 

--- a/returns/context/requires_context_ioresult.py
+++ b/returns/context/requires_context_ioresult.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -115,7 +117,7 @@ class RequiresContextIOResult(
     #: is just a function that returns `IOResult`.
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.
     _inner_value: Callable[
-        ['RequiresContextIOResult', _EnvType],
+        [RequiresContextIOResult, _EnvType],
         IOResult[_ValueType, _ErrorType],
     ]
 
@@ -167,7 +169,7 @@ class RequiresContextIOResult(
 
     def swap(
         self,
-    ) -> 'RequiresContextIOResult[_ErrorType, _ValueType, _EnvType]':
+    ) -> RequiresContextIOResult[_ErrorType, _ValueType, _EnvType]:
         """
         Swaps value and error types.
 
@@ -192,7 +194,7 @@ class RequiresContextIOResult(
 
     def map(  # noqa: WPS125
         self, function: Callable[[_ValueType], _NewValueType],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes successful container with a pure function.
 
@@ -215,12 +217,12 @@ class RequiresContextIOResult(
     def apply(
         self,
         container: Kind3[
-            'RequiresContextIOResult',
+            RequiresContextIOResult,
             Callable[[_ValueType], _NewValueType],
             _ErrorType,
             _EnvType,
         ],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Calls a wrapped function in a container on this container.
 
@@ -254,13 +256,13 @@ class RequiresContextIOResult(
         function: Callable[
             [_ValueType],
             Kind3[
-                'RequiresContextIOResult',
+                RequiresContextIOResult,
                 _NewValueType,
                 _ErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes this container with a function returning the same type.
 
@@ -300,8 +302,8 @@ class RequiresContextIOResult(
 
     def bind_result(
         self,
-        function: Callable[[_ValueType], 'Result[_NewValueType, _ErrorType]'],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+        function: Callable[[_ValueType], Result[_NewValueType, _ErrorType]],
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``Result`` returning function to the current container.
 
@@ -337,7 +339,7 @@ class RequiresContextIOResult(
             [_ValueType],
             'RequiresContext[_NewValueType, _EnvType]',
         ],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``RequiresContext`` returning function to current container.
 
@@ -372,7 +374,7 @@ class RequiresContextIOResult(
             [_ValueType],
             'RequiresContextResult[_NewValueType, _ErrorType, _EnvType]',
         ],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``RequiresContextResult`` returning function to the current one.
 
@@ -422,7 +424,7 @@ class RequiresContextIOResult(
     def bind_io(
         self,
         function: Callable[[_ValueType], IO[_NewValueType]],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``IO`` returning function to the current container.
 
@@ -450,7 +452,7 @@ class RequiresContextIOResult(
     def bind_ioresult(
         self,
         function: Callable[[_ValueType], IOResult[_NewValueType, _ErrorType]],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``IOResult`` returning function to the current container.
 
@@ -481,7 +483,7 @@ class RequiresContextIOResult(
 
     def alt(
         self, function: Callable[[_ErrorType], _NewErrorType],
-    ) -> 'RequiresContextIOResult[_ValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_ValueType, _NewErrorType, _EnvType]:
         """
         Composes failed container with a pure function.
 
@@ -506,13 +508,13 @@ class RequiresContextIOResult(
         function: Callable[
             [_ErrorType],
             Kind3[
-                'RequiresContextIOResult',
+                RequiresContextIOResult,
                 _ValueType,
                 _NewErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextIOResult[_ValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_ValueType, _NewErrorType, _EnvType]:
         """
         Composes this container with a function returning the same type.
 
@@ -554,13 +556,13 @@ class RequiresContextIOResult(
         function: Callable[
             [Result[_ValueType, _ErrorType]],
             Kind3[
-                'RequiresContextIOResult',
+                RequiresContextIOResult,
                 _NewValueType,
                 _ErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes inner ``Result`` with ``ReaderIOResult`` returning function.
 
@@ -594,7 +596,7 @@ class RequiresContextIOResult(
     def modify_env(
         self,
         function: Callable[[_NewEnvType], _EnvType],
-    ) -> 'RequiresContextIOResult[_ValueType, _ErrorType, _NewEnvType]':
+    ) -> RequiresContextIOResult[_ValueType, _ErrorType, _NewEnvType]:
         """
         Allows to modify the environment type.
 
@@ -615,7 +617,7 @@ class RequiresContextIOResult(
         return RequiresContextIOResult(lambda deps: self(function(deps)))
 
     @classmethod
-    def ask(cls) -> 'RequiresContextIOResult[_EnvType, _ErrorType, _EnvType]':
+    def ask(cls) -> RequiresContextIOResult[_EnvType, _ErrorType, _EnvType]:
         """
         Is used to get the current dependencies inside the call stack.
 
@@ -641,8 +643,8 @@ class RequiresContextIOResult(
 
     @classmethod
     def from_result(
-        cls, inner_value: 'Result[_NewValueType, _NewErrorType]',
-    ) -> 'RequiresContextIOResult[_NewValueType, _NewErrorType, NoDeps]':
+        cls, inner_value: Result[_NewValueType, _NewErrorType],
+    ) -> RequiresContextIOResult[_NewValueType, _NewErrorType, NoDeps]:
         """
         Creates new container with ``Result`` as a unit value.
 
@@ -670,7 +672,7 @@ class RequiresContextIOResult(
     def from_io(
         cls,
         inner_value: IO[_NewValueType],
-    ) -> 'RequiresContextIOResult[_NewValueType, Any, NoDeps]':
+    ) -> RequiresContextIOResult[_NewValueType, Any, NoDeps]:
         """
         Creates new container from successful ``IO`` value.
 
@@ -692,7 +694,7 @@ class RequiresContextIOResult(
     def from_failed_io(
         cls,
         inner_value: IO[_NewErrorType],
-    ) -> 'RequiresContextIOResult[Any, _NewErrorType, NoDeps]':
+    ) -> RequiresContextIOResult[Any, _NewErrorType, NoDeps]:
         """
         Creates a new container from failed ``IO`` value.
 
@@ -713,7 +715,7 @@ class RequiresContextIOResult(
     @classmethod
     def from_ioresult(
         cls, inner_value: IOResult[_NewValueType, _NewErrorType],
-    ) -> 'RequiresContextIOResult[_NewValueType, _NewErrorType, NoDeps]':
+    ) -> RequiresContextIOResult[_NewValueType, _NewErrorType, NoDeps]:
         """
         Creates new container with ``IOResult`` as a unit value.
 
@@ -738,8 +740,8 @@ class RequiresContextIOResult(
     def from_ioresult_context(
         cls,
         inner_value:
-            'ReaderIOResult[_NewValueType, _NewErrorType, _NewEnvType]',
-    ) -> 'ReaderIOResult[_NewValueType, _NewErrorType, _NewEnvType]':
+            ReaderIOResult[_NewValueType, _NewErrorType, _NewEnvType],
+    ) -> ReaderIOResult[_NewValueType, _NewErrorType, _NewEnvType]:
         """
         Creates new container with ``ReaderIOResult`` as a unit value.
 
@@ -764,7 +766,7 @@ class RequiresContextIOResult(
         cls,
         inner_value:
             'RequiresContext[IOResult[_NewValueType, _NewErrorType], _EnvType]',
-    ) -> 'RequiresContextIOResult[_NewValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _NewErrorType, _EnvType]:
         """
         You might end up with ``RequiresContext[IOResult]`` as a value.
 
@@ -792,7 +794,7 @@ class RequiresContextIOResult(
     @classmethod
     def from_context(
         cls, inner_value: 'RequiresContext[_NewValueType, _NewEnvType]',
-    ) -> 'RequiresContextIOResult[_NewValueType, Any, _NewEnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, Any, _NewEnvType]:
         """
         Creates new container from ``RequiresContext`` as a success unit.
 
@@ -813,7 +815,7 @@ class RequiresContextIOResult(
     @classmethod
     def from_failed_context(
         cls, inner_value: 'RequiresContext[_NewValueType, _NewEnvType]',
-    ) -> 'RequiresContextIOResult[Any, _NewValueType, _NewEnvType]':
+    ) -> RequiresContextIOResult[Any, _NewValueType, _NewEnvType]:
         """
         Creates new container from ``RequiresContext`` as a failure unit.
 
@@ -836,7 +838,7 @@ class RequiresContextIOResult(
         cls,
         inner_value:
             'RequiresContextResult[_NewValueType, _NewErrorType, _NewEnvType]',
-    ) -> 'RequiresContextIOResult[_NewValueType, _NewErrorType, _NewEnvType]':
+    ) -> RequiresContextIOResult[_NewValueType, _NewErrorType, _NewEnvType]:
         """
         Creates new container from ``RequiresContextResult`` as a unit value.
 
@@ -862,7 +864,7 @@ class RequiresContextIOResult(
     def from_value(
         cls,
         inner_value: _NewValueType,
-    ) -> 'RequiresContextIOResult[_NewValueType, Any, NoDeps]':
+    ) -> RequiresContextIOResult[_NewValueType, Any, NoDeps]:
         """
         Creates new container with ``IOSuccess(inner_value)`` as a unit value.
 
@@ -882,7 +884,7 @@ class RequiresContextIOResult(
     def from_failure(
         cls,
         inner_value: _NewErrorType,
-    ) -> 'RequiresContextIOResult[Any, _NewErrorType, NoDeps]':
+    ) -> RequiresContextIOResult[Any, _NewErrorType, NoDeps]:
         """
         Creates new container with ``IOFailure(inner_value)`` as a unit value.
 
@@ -903,14 +905,14 @@ class RequiresContextIOResult(
         cls,
         inner_value: Iterable[
             Kind3[
-                'RequiresContextIOResult',
+                RequiresContextIOResult,
                 _NewValueType,
                 _NewErrorType,
                 _NewEnvType,
             ],
         ],
         strategy: Type[BaseIterableStrategyN] = FailFast,
-    ) -> 'ReaderIOResult[Sequence[_NewValueType], _NewErrorType, _NewEnvType]':
+    ) -> ReaderIOResult[Sequence[_NewValueType], _NewErrorType, _NewEnvType]:
         """
         Transforms an iterable of ``RequiresContextIOResult`` containers.
 

--- a/returns/context/requires_context_result.py
+++ b/returns/context/requires_context_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -104,7 +106,7 @@ class RequiresContextResult(
 
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.
     _inner_value: Callable[
-        ['RequiresContextResult', _EnvType],
+        [RequiresContextResult, _EnvType],
         Result[_ValueType, _ErrorType],
     ]
 
@@ -154,7 +156,7 @@ class RequiresContextResult(
         """
         return self._inner_value(deps)
 
-    def swap(self) -> 'RequiresContextResult[_ErrorType, _ValueType, _EnvType]':
+    def swap(self) -> RequiresContextResult[_ErrorType, _ValueType, _EnvType]:
         """
         Swaps value and error types.
 
@@ -179,7 +181,7 @@ class RequiresContextResult(
 
     def map(  # noqa: WPS125
         self, function: Callable[[_ValueType], _NewValueType],
-    ) -> 'RequiresContextResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes successful container with a pure function.
 
@@ -202,12 +204,12 @@ class RequiresContextResult(
     def apply(
         self,
         container: Kind3[
-            'RequiresContextResult',
+            RequiresContextResult,
             Callable[[_ValueType], _NewValueType],
             _ErrorType,
             _EnvType,
         ],
-    ) -> 'RequiresContextResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Calls a wrapped function in a container on this container.
 
@@ -241,13 +243,13 @@ class RequiresContextResult(
         function: Callable[
             [_ValueType],
             Kind3[
-                'RequiresContextResult',
+                RequiresContextResult,
                 _NewValueType,
                 _ErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Composes this container with a function returning the same type.
 
@@ -286,7 +288,7 @@ class RequiresContextResult(
     def bind_result(
         self,
         function: Callable[[_ValueType], Result[_NewValueType, _ErrorType]],
-    ) -> 'RequiresContextResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``Result`` returning function to current container.
 
@@ -319,7 +321,7 @@ class RequiresContextResult(
             [_ValueType],
             'RequiresContext[_NewValueType, _EnvType]',
         ],
-    ) -> 'RequiresContextResult[_NewValueType, _ErrorType, _EnvType]':
+    ) -> RequiresContextResult[_NewValueType, _ErrorType, _EnvType]:
         """
         Binds ``RequiresContext`` returning function to current container.
 
@@ -350,7 +352,7 @@ class RequiresContextResult(
 
     def alt(
         self, function: Callable[[_ErrorType], _NewErrorType],
-    ) -> 'RequiresContextResult[_ValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextResult[_ValueType, _NewErrorType, _EnvType]:
         """
         Composes failed container with a pure function.
 
@@ -375,13 +377,13 @@ class RequiresContextResult(
         function: Callable[
             [_ErrorType],
             Kind3[
-                'RequiresContextResult',
+                RequiresContextResult,
                 _ValueType,
                 _NewErrorType,
                 _EnvType,
             ],
         ],
-    ) -> 'RequiresContextResult[_ValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextResult[_ValueType, _NewErrorType, _EnvType]:
         """
         Composes this container with a function returning the same type.
 
@@ -419,7 +421,7 @@ class RequiresContextResult(
     def modify_env(
         self,
         function: Callable[[_NewEnvType], _EnvType],
-    ) -> 'RequiresContextResult[_ValueType, _ErrorType, _NewEnvType]':
+    ) -> RequiresContextResult[_ValueType, _ErrorType, _NewEnvType]:
         """
         Allows to modify the environment type.
 
@@ -440,7 +442,7 @@ class RequiresContextResult(
         return RequiresContextResult(lambda deps: self(function(deps)))
 
     @classmethod
-    def ask(cls) -> 'RequiresContextResult[_EnvType, _ErrorType, _EnvType]':
+    def ask(cls) -> RequiresContextResult[_EnvType, _ErrorType, _EnvType]:
         """
         Is used to get the current dependencies inside the call stack.
 
@@ -467,7 +469,7 @@ class RequiresContextResult(
     @classmethod
     def from_result(
         cls, inner_value: Result[_NewValueType, _NewErrorType],
-    ) -> 'RequiresContextResult[_NewValueType, _NewErrorType, NoDeps]':
+    ) -> RequiresContextResult[_NewValueType, _NewErrorType, NoDeps]:
         """
         Creates new container with ``Result`` as a unit value.
 
@@ -493,7 +495,7 @@ class RequiresContextResult(
         cls,
         inner_value:
             'RequiresContext[Result[_NewValueType, _NewErrorType], _EnvType]',
-    ) -> 'RequiresContextResult[_NewValueType, _NewErrorType, _EnvType]':
+    ) -> RequiresContextResult[_NewValueType, _NewErrorType, _EnvType]:
         """
         You might end up with ``RequiresContext[Result[...]]`` as a value.
 
@@ -521,7 +523,7 @@ class RequiresContextResult(
     @classmethod
     def from_context(
         cls, inner_value: 'RequiresContext[_NewValueType, _NewEnvType]',
-    ) -> 'RequiresContextResult[_NewValueType, Any, _NewEnvType]':
+    ) -> RequiresContextResult[_NewValueType, Any, _NewEnvType]:
         """
         Creates new container from ``RequiresContext`` as a success unit.
 
@@ -539,7 +541,7 @@ class RequiresContextResult(
     @classmethod
     def from_failed_context(
         cls, inner_value: 'RequiresContext[_NewValueType, _NewEnvType]',
-    ) -> 'RequiresContextResult[Any, _NewValueType, _NewEnvType]':
+    ) -> RequiresContextResult[Any, _NewValueType, _NewEnvType]:
         """
         Creates new container from ``RequiresContext`` as a failure unit.
 
@@ -558,8 +560,8 @@ class RequiresContextResult(
     def from_result_context(
         cls,
         inner_value:
-            'RequiresContextResult[_NewValueType, _NewErrorType, _NewEnvType]',
-    ) -> 'RequiresContextResult[_NewValueType, _NewErrorType, _NewEnvType]':
+            RequiresContextResult[_NewValueType, _NewErrorType, _NewEnvType],
+    ) -> RequiresContextResult[_NewValueType, _NewErrorType, _NewEnvType]:
         """
         Creates ``RequiresContextResult`` from another instance of it.
 
@@ -582,7 +584,7 @@ class RequiresContextResult(
     @classmethod
     def from_value(
         cls, inner_value: _FirstType,
-    ) -> 'RequiresContextResult[_FirstType, Any, NoDeps]':
+    ) -> RequiresContextResult[_FirstType, Any, NoDeps]:
         """
         Creates new container with ``Success(inner_value)`` as a unit value.
 
@@ -598,7 +600,7 @@ class RequiresContextResult(
     @classmethod
     def from_failure(
         cls, inner_value: _FirstType,
-    ) -> 'RequiresContextResult[Any, _FirstType, NoDeps]':
+    ) -> RequiresContextResult[Any, _FirstType, NoDeps]:
         """
         Creates new container with ``Failure(inner_value)`` as a unit value.
 
@@ -616,14 +618,14 @@ class RequiresContextResult(
         cls,
         inner_value: Iterable[
             Kind3[
-                'RequiresContextResult',
+                RequiresContextResult,
                 _NewValueType,
                 _NewErrorType,
                 _NewEnvType,
             ],
         ],
         strategy: Type[BaseIterableStrategyN] = FailFast,
-    ) -> 'ReaderResult[Sequence[_NewValueType], _NewErrorType, _NewEnvType]':
+    ) -> ReaderResult[Sequence[_NewValueType], _NewErrorType, _NewEnvType]:
         """
         Transforms an iterable of ``RequiresContextResult`` containers.
 

--- a/returns/contrib/hypothesis/containers.py
+++ b/returns/contrib/hypothesis/containers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Callable, List, Type, TypeVar
 
 from hypothesis import strategies as st

--- a/returns/interfaces/specific/future.py
+++ b/returns/interfaces/specific/future.py
@@ -6,6 +6,8 @@ Don't use this type for async that can. Instead, use
 :class:`returns.interfaces.specific.future_result.FutureResultBasedN` type.
 """
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,

--- a/returns/interfaces/specific/future_result.py
+++ b/returns/interfaces/specific/future_result.py
@@ -6,6 +6,8 @@ This type means that ``FutureResult`` can (and will!) fail with exceptions.
 Use this type to mark that this specific async opetaion can fail.
 """
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Awaitable, Callable, NoReturn, Type, TypeVar
 

--- a/returns/interfaces/specific/io.py
+++ b/returns/interfaces/specific/io.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Callable, NoReturn, Type, TypeVar
 

--- a/returns/interfaces/specific/ioresult.py
+++ b/returns/interfaces/specific/ioresult.py
@@ -4,6 +4,8 @@ An interface for types that do ``IO`` and can fail.
 It is a base interface for both sync and async ``IO`` stacks.
 """
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Callable, NoReturn, Type, TypeVar
 

--- a/returns/interfaces/specific/reader.py
+++ b/returns/interfaces/specific/reader.py
@@ -24,6 +24,8 @@ See also:
 
 """
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -213,7 +215,7 @@ class _LawSpec(LawSpecDef):
 
     @law_definition
     def purity_law(
-        container: 'ReaderBased2[_FirstType, _SecondType]',
+        container: ReaderBased2[_FirstType, _SecondType],
         env: _SecondType,
     ) -> None:
         """Calling a ``Reader`` twice has the same result with the same env."""
@@ -221,7 +223,7 @@ class _LawSpec(LawSpecDef):
 
     @law_definition
     def asking_law(
-        container: 'ReaderBased2[_FirstType, _SecondType]',
+        container: ReaderBased2[_FirstType, _SecondType],
         env: _SecondType,
     ) -> None:
         """Asking for an env, always returns the env."""

--- a/returns/interfaces/specific/reader_future_result.py
+++ b/returns/interfaces/specific/reader_future_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -106,7 +108,7 @@ class _LawSpec(LawSpecDef):
     @law_definition
     def asking_law(
         container:
-            'ReaderFutureResultBasedN[_FirstType, _SecondType, _ThirdType]',
+            ReaderFutureResultBasedN[_FirstType, _SecondType, _ThirdType],
         env: _ThirdType,
     ) -> None:
         """Asking for an env, always returns the env."""

--- a/returns/interfaces/specific/reader_ioresult.py
+++ b/returns/interfaces/specific/reader_ioresult.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Callable, ClassVar, Sequence, Type, TypeVar
 
@@ -72,7 +74,7 @@ class _LawSpec(LawSpecDef):
 
     @law_definition
     def asking_law(
-        container: 'ReaderIOResultBasedN[_FirstType, _SecondType, _ThirdType]',
+        container: ReaderIOResultBasedN[_FirstType, _SecondType, _ThirdType],
         env: _ThirdType,
     ) -> None:
         """Asking for an env, always returns the env."""

--- a/returns/interfaces/specific/reader_result.py
+++ b/returns/interfaces/specific/reader_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Callable, ClassVar, Sequence, Type, TypeVar
 
@@ -80,7 +82,7 @@ class _LawSpec(LawSpecDef):
 
     @law_definition
     def purity_law(
-        container: 'ReaderResultBasedN[_FirstType, _SecondType, _ThirdType]',
+        container: ReaderResultBasedN[_FirstType, _SecondType, _ThirdType],
         env: _ThirdType,
     ) -> None:
         """Calling a ``Reader`` twice has the same result with the same env."""
@@ -88,7 +90,7 @@ class _LawSpec(LawSpecDef):
 
     @law_definition
     def asking_law(
-        container: 'ReaderResultBasedN[_FirstType, _SecondType, _ThirdType]',
+        container: ReaderResultBasedN[_FirstType, _SecondType, _ThirdType],
         env: _ThirdType,
     ) -> None:
         """Asking for an env, always returns the env."""

--- a/returns/interfaces/specific/result.py
+++ b/returns/interfaces/specific/result.py
@@ -5,6 +5,8 @@ For impure result see
 :class:`returns.interfaces.specific.ioresult.IOResultLikeN` type.
 """
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -64,7 +66,7 @@ class _LawSpec(LawSpecDef):
     @law_definition
     def map_short_circuit_law(
         raw_value: _SecondType,
-        container: 'ResultLikeN[_FirstType, _SecondType, _ThirdType]',
+        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
         function: Callable[[_FirstType], _NewType1],
     ) -> None:
         """Ensures that you cannot map a failure."""
@@ -76,10 +78,10 @@ class _LawSpec(LawSpecDef):
     @law_definition
     def bind_short_circuit_law(
         raw_value: _SecondType,
-        container: 'ResultLikeN[_FirstType, _SecondType, _ThirdType]',
+        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
         function: Callable[
             [_FirstType],
-            KindN['ResultLikeN', _NewType1, _SecondType, _ThirdType],
+            KindN[ResultLikeN, _NewType1, _SecondType, _ThirdType],
         ],
     ) -> None:
         """
@@ -95,7 +97,7 @@ class _LawSpec(LawSpecDef):
     @law_definition
     def alt_short_circuit_law(
         raw_value: _SecondType,
-        container: 'ResultLikeN[_FirstType, _SecondType, _ThirdType]',
+        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
         function: Callable[[_SecondType], _NewType1],
     ) -> None:
         """Ensures that you cannot alt a success."""
@@ -107,10 +109,10 @@ class _LawSpec(LawSpecDef):
     @law_definition
     def rescue_short_circuit_law(
         raw_value: _FirstType,
-        container: 'ResultLikeN[_FirstType, _SecondType, _ThirdType]',
+        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
         function: Callable[
             [_SecondType],
-            KindN['ResultLikeN', _FirstType, _NewType1, _ThirdType],
+            KindN[ResultLikeN, _FirstType, _NewType1, _ThirdType],
         ],
     ) -> None:
         """Ensures that you cannot rescue a success."""

--- a/returns/io.py
+++ b/returns/io.py
@@ -578,6 +578,7 @@ class IOResult(
         Get value from successful container or raise exception for failed one.
 
         .. code:: pycon
+          :force:
 
           >>> from returns.io import IO, IOFailure, IOSuccess
           >>> assert IOSuccess(1).unwrap() == IO(1)
@@ -587,7 +588,7 @@ class IOResult(
             ...
           returns.primitives.exceptions.UnwrapFailedError
 
-        """
+        """  # noqa: RST399
         return IO(self._inner_value.unwrap())
 
     def failure(self) -> IO[_ErrorType]:
@@ -595,6 +596,7 @@ class IOResult(
         Get failed value from failed container or raise exception from success.
 
         .. code:: pycon
+          :force:
 
           >>> from returns.io import IO, IOFailure, IOSuccess
           >>> assert IOFailure(1).failure() == IO(1)
@@ -604,7 +606,7 @@ class IOResult(
             ...
           returns.primitives.exceptions.UnwrapFailedError
 
-        """
+        """  # noqa: RST399
         return IO(self._inner_value.failure())
 
     def compose_result(

--- a/returns/maybe.py
+++ b/returns/maybe.py
@@ -217,6 +217,7 @@ class Maybe(
         Get value from successful container or raise exception for failed one.
 
         .. code:: pycon
+          :force:
 
           >>> from returns.maybe import Nothing, Some
           >>> assert Some(1).unwrap() == 1
@@ -226,13 +227,14 @@ class Maybe(
             ...
           returns.primitives.exceptions.UnwrapFailedError
 
-        """
+        """  # noqa: RST399
 
     def failure(self) -> None:
         """
         Get failed value from failed container or raise exception from success.
 
         .. code:: pycon
+          :force:
 
           >>> from returns.maybe import Nothing, Some
           >>> assert Nothing.failure() is None
@@ -242,7 +244,7 @@ class Maybe(
             ...
           returns.primitives.exceptions.UnwrapFailedError
 
-        """
+        """  # noqa: RST399
 
     @classmethod
     def from_value(

--- a/returns/pointfree/bind_context.py
+++ b/returns/pointfree/bind_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from returns.interfaces.specific.reader import ReaderLike2, ReaderLike3

--- a/returns/pointfree/bind_context_ioresult.py
+++ b/returns/pointfree/bind_context_ioresult.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from returns.interfaces.specific.reader_ioresult import ReaderIOResultLikeN

--- a/returns/pointfree/bind_context_result.py
+++ b/returns/pointfree/bind_context_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from returns.interfaces.specific.reader_result import ReaderResultLikeN

--- a/returns/pointfree/bind_io.py
+++ b/returns/pointfree/bind_io.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from returns.interfaces.specific.io import IOLikeN

--- a/returns/pointfree/bind_ioresult.py
+++ b/returns/pointfree/bind_ioresult.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from returns.interfaces.specific.ioresult import IOResultLikeN

--- a/returns/pointfree/bind_result.py
+++ b/returns/pointfree/bind_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, TypeVar
 
 from returns.interfaces.specific.result import ResultLikeN

--- a/returns/primitives/exceptions.py
+++ b/returns/primitives/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/returns/primitives/types.py
+++ b/returns/primitives/types.py
@@ -11,6 +11,7 @@ class Immutable(object):
     Nothing can be added or deleted from it.
 
     .. code:: pycon
+      :force:
 
       >>> from returns.primitives.types import Immutable
       >>> class MyModel(Immutable):
@@ -24,7 +25,7 @@ class Immutable(object):
 
     See :class:`returns.primitives.container.BaseContainer` for examples.
 
-    """
+    """  # noqa: RST399
 
     def __copy__(self) -> 'Immutable':
         """Returns itself."""

--- a/returns/result.py
+++ b/returns/result.py
@@ -225,6 +225,7 @@ class Result(
         Get value or raise exception.
 
         .. code:: pycon
+          :force:
 
           >>> from returns.result import Failure, Success
           >>> assert Success(1).unwrap() == 1
@@ -234,13 +235,14 @@ class Result(
             ...
           returns.primitives.exceptions.UnwrapFailedError
 
-        """
+        """  # noqa: RST399
 
     def failure(self) -> _ErrorType:
         """
         Get failed value or raise exception.
 
         .. code:: pycon
+          :force:
 
           >>> from returns.result import Failure, Success
           >>> assert Failure(1).failure() == 1
@@ -250,7 +252,7 @@ class Result(
             ...
           returns.primitives.exceptions.UnwrapFailedError
 
-        """
+        """  # noqa: RST399
 
     @classmethod
     def from_value(

--- a/setup.cfg
+++ b/setup.cfg
@@ -171,3 +171,4 @@ show_traceback = True
 ignore-path = docs/_build
 max-line-length = 80
 sphinx = True
+ignore-path-errors=docs/pages/railway.rst;D000


### PR DESCRIPTION
I've fixed all documentation warnings and created `.readthedocs.yml` to active the `fail_on_warning` flag!!
But we have a problem here, to fix the warnings about `ForwardReference` I've added the imports `from __future__ import annotations`, unfortunately the hypothesis' tests are failing. I think it's related to this issue: https://github.com/HypothesisWorks/hypothesis/issues/2565

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)

## Related issues

Closes #568 