### PR TITLE
Fix docs warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,11 @@ extensions = [
     # Used to insert typehints into the final docs:
     'sphinx_autodoc_typehints',
 
+    # Our custom sphinx plugin
+    # Should be removed after `sphinx` 3.3.0 release
+    # https://github.com/sphinx-doc/sphinx/pull/8202
+    'docs.plugin',
+
     # Used to build graphs:
     'sphinxcontrib.mermaid',
 

--- a/docs/pages/pointfree.rst
+++ b/docs/pages/pointfree.rst
@@ -291,7 +291,7 @@ API Reference
 
 .. autofunction:: returns.pointfree.bind_awaitable
 
-.. autofunction:: returns.pointfree.bind_optional.bind_optional
+.. autofunction:: returns.pointfree.bind_optional
 
 .. autofunction:: returns.pointfree.compose_result
 

--- a/docs/plugin.py
+++ b/docs/plugin.py
@@ -1,0 +1,23 @@
+def processe_docstring(  # noqa: WPS211
+    app, what, name, object_, options, lines,
+):
+    """
+    This function will process a docstring.
+
+    Currently we have a problem using `sphinx_autodoc_typehints` plugin,
+    it does not add a blank line after the content insertion.
+    This function will insert the blank line if the last processed line has
+    some content.
+    An important thing, our plugin has to be added right after
+    `sphinx_autodoc_typehints` in the extensions list!
+    """
+    if lines:
+        last_line_has_content = bool(lines[-1])
+        if last_line_has_content:
+            lines.append('')
+
+
+def setup(app):
+    """Register a function to receive an event from sphinx."""
+    app.connect('autodoc-process-docstring', processe_docstring)
+    return dict(parallel_read_safe=True)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,7 @@ sphinx-hoverxref==0.5b1
 recommonmark==0.6.0
 m2r==0.2.1
 tomlkit==0.7.0
+pygments==2.7.1
 
 # Dependencies of our project:
 typing-extensions==3.7.4.3


### PR DESCRIPTION
# Fix docs warnings

After the merge of #614 the RTD build failed, unfortunately the build environment differences has contributed to this!!

Changes:

### Adds explicitly `pygments` version.

#### Why?

RTD build has 3 steps install.
 1. Upgrade `pip`
2. Install its basic setup:
```text
Pygments==2.3.1 setuptools==41.0.1  mock==1.0.1 pillow==5.4.1 alabaster>=0.7,<0.8,!=0.7.5 commonmark==0.8.1 recommonmark==0.5.0 sphinx<2 sphinx-rtd-theme<0.5 readthedocs-sphinx-ext<1.1
```
3. Install our `requirements` file 

Because the installation of `Pygments==2.3.1` in the second step we've got the following error:
```text
/home/docs/checkouts/readthedocs.org/user_builds/returns/checkouts/latest/docs/pages/contrib/mypy_plugins.rst:42: WARNING: Pygments lexer name 'toml' is not known
```
The `toml` lexer was added in `2.4.0` pygments version

___P.S.:___: `Sphinx` has the `pygments` dependency too, but its constraint does not subscribe the old version because it's `Pugments>2.0`

### Resolves `autofunction` error in `pointfree.rst`

It's just a minor mistake that generates the following error:
```text
WARNING: autodoc: failed to import function 'bind_optional.bind_optional' from module 'returns.pointfree'; the following exception was raised:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/returns/envs/latest/lib/python3.7/site-packages/sphinx/util/inspect.py", line 324, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: 'function' object has no attribute 'bind_optional'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/returns/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/importer.py", line 71, in import_object
    obj = attrgetter(obj, attrname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/returns/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 246, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/returns/envs/latest/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 2078, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/returns/envs/latest/lib/python3.7/site-packages/sphinx/util/inspect.py", line 340, in safe_getattr
    raise AttributeError(name)
AttributeError: bind_optional
```
I just changed from:
```rst
.. autofunction:: returns.pointfree.bind_optional.bind_optional
```
to:
```rst
.. autofunction:: returns.pointfree.bind_optional
```

### Creates sphinx plugin

I've created a simple `sphinx` plugin to add a blank line after the content processed by `sphinx_autodoc_typehints`.
With that we do not have more warnings!

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)

## Related issues

Refs #568
