### PR TITLE
Creates `failable` interfaces

### DIFF
--- a/docs/pages/interfaces.rst
+++ b/docs/pages/interfaces.rst
@@ -452,6 +452,7 @@ Here's a full overview of all our interfaces:
    returns.interfaces.bimappable
    returns.interfaces.unwrappable
    returns.interfaces.container
+   returns.interfaces.failable
    returns.interfaces.specific.maybe
    returns.interfaces.specific.result
    returns.interfaces.specific.io
@@ -563,6 +564,16 @@ Container
    :strict:
 
 .. automodule:: returns.interfaces.container
+  :members:
+  :private-members:
+
+Failable
+~~~~~~~~
+
+.. autoclasstree:: returns.interfaces.failable
+   :strict:
+
+.. automodule:: returns.interfaces.failable
   :members:
   :private-members:
 

--- a/docs/pages/pointfree.rst
+++ b/docs/pages/pointfree.rst
@@ -218,8 +218,8 @@ kind of manipulation.
 cond
 ----
 
-Sometimes we need to create ``ResultLikeN`` containers based on a boolean
-expression, ``cond`` can help us.
+Sometimes we need to create ``DiverseFailableN`` containers
+(e.g. ``ResultLikeN``) based on a boolean expression, ``cond`` can help us.
 
 See the example below:
 

--- a/returns/interfaces/failable.py
+++ b/returns/interfaces/failable.py
@@ -1,0 +1,261 @@
+from abc import abstractmethod
+from typing import Callable, ClassVar, NoReturn, Sequence, Type, TypeVar
+
+from typing_extensions import final
+
+from returns.interfaces.bimappable import BiMappableN
+from returns.interfaces.container import ContainerN
+from returns.interfaces.rescuable import RescuableN
+from returns.primitives.asserts import assert_equal
+from returns.primitives.hkt import KindN
+from returns.primitives.laws import (
+    Law,
+    Law2,
+    Law3,
+    Lawful,
+    LawSpecDef,
+    law_definition,
+)
+
+_FirstType = TypeVar('_FirstType')
+_SecondType = TypeVar('_SecondType')
+_ThirdType = TypeVar('_ThirdType')
+_UpdatedType = TypeVar('_UpdatedType')
+
+_SingleFailableType = TypeVar('_SingleFailableType', bound='SingleFailableN')
+_DiverseFailableType = TypeVar('_DiverseFailableType', bound='DiverseFailableN')
+
+# Used in laws:
+_NewFirstType = TypeVar('_NewFirstType')
+_NewSecondType = TypeVar('_NewSecondType')
+
+
+@final
+class _FailableLawSpec(LawSpecDef):
+    """
+    Failable laws.
+
+    We need to be sure that ``.rescue`` won't rescue success types.
+    """
+
+    @law_definition
+    def rescue_short_circuit_law(
+        raw_value: _FirstType,
+        container: 'FailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[
+            [_SecondType],
+            KindN['FailableN', _FirstType, _NewFirstType, _ThirdType],
+        ],
+    ) -> None:
+        """Ensures that you cannot rescue a success."""
+        assert_equal(
+            container.from_value(raw_value),
+            container.from_value(raw_value).rescue(function),
+        )
+
+
+class FailableN(
+    ContainerN[_FirstType, _SecondType, _ThirdType],
+    RescuableN[_FirstType, _SecondType, _ThirdType],
+    Lawful['FailableN[_FirstType, _SecondType, _ThirdType]'],
+):
+    """
+    Base type for types that can fail.
+
+    It is a raw type and should not be used directly.
+    Use ``SingleFailableN`` and ``DiverseFailableN`` instead.
+    """
+
+    _laws: ClassVar[Sequence[Law]] = (
+        Law3(_FailableLawSpec.rescue_short_circuit_law),
+    )
+
+
+#: Type alias for kinds with two type arguments.
+Failable2 = FailableN[_FirstType, _SecondType, NoReturn]
+
+#: Type alias for kinds with three type arguments.
+Failable3 = FailableN[_FirstType, _SecondType, _ThirdType]
+
+
+@final
+class _SingleFailableLawSpec(LawSpecDef):
+    """
+    Single Failable laws.
+
+    We need to be sure that ``.map`` and ``.bind``
+    works correctly for ``empty`` property.
+    """
+
+    @law_definition
+    def map_short_circuit_law(
+        container: 'SingleFailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[[_FirstType], _NewFirstType],
+    ) -> None:
+        """Ensures that you cannot map from the `empty` property."""
+        assert_equal(
+            container.empty,
+            container.empty.map(function),
+        )
+
+    @law_definition
+    def bind_short_circuit_law(
+        container: 'SingleFailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[
+            [_FirstType],
+            KindN['SingleFailableN', _NewFirstType, _SecondType, _ThirdType],
+        ],
+    ) -> None:
+        """Ensures that you cannot bind from the `empty` property."""
+        assert_equal(
+            container.empty,
+            container.empty.bind(function),
+        )
+
+    @law_definition
+    def apply_short_circuit_law(
+        container: 'SingleFailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[[_FirstType], _NewFirstType],
+    ) -> None:
+        """Ensures that you cannot apply from the `empty` property."""
+        wrapped_function = container.from_value(function)
+        assert_equal(
+            container.empty,
+            container.empty.apply(wrapped_function),
+        )
+
+
+class SingleFailableN(
+    FailableN[_FirstType, _SecondType, _ThirdType],
+):
+    """
+    Base type for types that have just only one failed value.
+
+    Like ``Maybe`` types where the only failed value is ``Nothing``.
+    """
+
+    _laws: ClassVar[Sequence[Law]] = (
+        Law2(_SingleFailableLawSpec.map_short_circuit_law),
+        Law2(_SingleFailableLawSpec.bind_short_circuit_law),
+        Law2(_SingleFailableLawSpec.apply_short_circuit_law),
+    )
+
+    @property
+    @abstractmethod
+    def empty(
+        self: _SingleFailableType,
+    ) -> 'SingleFailableN[_FirstType, _SecondType, _ThirdType]':
+        """This property represents the failed value."""
+
+
+#: Type alias for kinds with two types arguments.
+SingleFailable2 = SingleFailableN[_FirstType, _SecondType, NoReturn]
+
+#: Type alias for kinds with three type arguments.
+SingleFailable3 = SingleFailableN[_FirstType, _SecondType, _ThirdType]
+
+
+@final
+class _DiverseFailableLawSpec(LawSpecDef):
+    """
+    Diverse Failable laws.
+
+    We need to be sure that ``.map``, ``.bind``, ``.apply`` and ``.alt``
+    works correctly for both success and failure types.
+    """
+
+    @law_definition
+    def map_short_circuit_law(
+        raw_value: _SecondType,
+        container: 'DiverseFailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[[_FirstType], _NewFirstType],
+    ) -> None:
+        """Ensures that you cannot map a failure."""
+        assert_equal(
+            container.from_failure(raw_value),
+            container.from_failure(raw_value).map(function),
+        )
+
+    @law_definition
+    def bind_short_circuit_law(
+        raw_value: _SecondType,
+        container: 'DiverseFailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[
+            [_FirstType],
+            KindN['DiverseFailableN', _NewFirstType, _SecondType, _ThirdType],
+        ],
+    ) -> None:
+        """
+        Ensures that you cannot bind a failure.
+
+        See: https://wiki.haskell.org/Typeclassopedia#MonadFail
+        """
+        assert_equal(
+            container.from_failure(raw_value),
+            container.from_failure(raw_value).bind(function),
+        )
+
+    @law_definition
+    def apply_short_circuit_law(
+        raw_value: _SecondType,
+        container: 'DiverseFailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[[_FirstType], _NewFirstType],
+    ) -> None:
+        """Ensures that you cannot apply a failure."""
+        wrapped_function = container.from_value(function)
+        assert_equal(
+            container.from_failure(raw_value),
+            container.from_failure(raw_value).apply(wrapped_function),
+        )
+
+    @law_definition
+    def alt_short_circuit_law(
+        raw_value: _SecondType,
+        container: 'DiverseFailableN[_FirstType, _SecondType, _ThirdType]',
+        function: Callable[[_SecondType], _NewFirstType],
+    ) -> None:
+        """Ensures that you cannot alt a success."""
+        assert_equal(
+            container.from_value(raw_value),
+            container.from_value(raw_value).alt(function),
+        )
+
+
+class DiverseFailableN(
+    FailableN[_FirstType, _SecondType, _ThirdType],
+    BiMappableN[_FirstType, _SecondType, _ThirdType],
+    Lawful['DiverseFailableN[_FirstType, _SecondType, _ThirdType]'],
+):
+    """
+    Base type for types that have any failed value.
+
+    Like ``Result`` types.
+    """
+
+    _laws: ClassVar[Sequence[Law]] = (
+        Law3(_DiverseFailableLawSpec.map_short_circuit_law),
+        Law3(_DiverseFailableLawSpec.bind_short_circuit_law),
+        Law3(_DiverseFailableLawSpec.apply_short_circuit_law),
+        Law3(_DiverseFailableLawSpec.alt_short_circuit_law),
+    )
+
+    @abstractmethod
+    def swap(
+        self: _DiverseFailableType,
+    ) -> KindN[_DiverseFailableType, _SecondType, _FirstType, _ThirdType]:
+        """Swaps value and error types in ``DiverseFailableN``."""
+
+    @classmethod
+    @abstractmethod
+    def from_failure(
+        cls: Type[_DiverseFailableType],
+        inner_value: _UpdatedType,
+    ) -> KindN[_DiverseFailableType, _FirstType, _UpdatedType, _ThirdType]:
+        """Unit method to create new containers from any raw value."""
+
+
+#: Type alias for kinds with two type arguments.
+DiverseFailable2 = DiverseFailableN[_FirstType, _SecondType, NoReturn]
+
+#: Type alias for kinds with three type arguments.
+DiverseFailable3 = DiverseFailableN[_FirstType, _SecondType, _ThirdType]

--- a/returns/interfaces/specific/maybe.py
+++ b/returns/interfaces/specific/maybe.py
@@ -12,8 +12,7 @@ from typing import (
 
 from typing_extensions import final
 
-from returns.interfaces import equable, rescuable, unwrappable
-from returns.interfaces.container import ContainerN
+from returns.interfaces import equable, failable, unwrappable
 from returns.primitives.asserts import assert_equal
 from returns.primitives.hkt import KindN
 from returns.primitives.laws import (
@@ -113,8 +112,7 @@ class _LawSpec(LawSpecDef):
 
 
 class MaybeLikeN(
-    ContainerN[_FirstType, _SecondType, _ThirdType],
-    rescuable.RescuableN[_FirstType, _SecondType, _ThirdType],
+    failable.SingleFailableN[_FirstType, _SecondType, _ThirdType],
     Lawful['MaybeLikeN[_FirstType, _SecondType, _ThirdType]'],
 ):
     """

--- a/returns/interfaces/specific/result.py
+++ b/returns/interfaces/specific/result.py
@@ -8,29 +8,10 @@ For impure result see
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    ClassVar,
-    NoReturn,
-    Sequence,
-    Type,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Callable, NoReturn, Type, TypeVar
 
-from typing_extensions import final
-
-from returns.interfaces import bimappable, equable, rescuable, unwrappable
-from returns.interfaces.container import ContainerN
-from returns.primitives.asserts import assert_equal
+from returns.interfaces import equable, failable, unwrappable
 from returns.primitives.hkt import KindN
-from returns.primitives.laws import (
-    Law,
-    Law3,
-    Lawful,
-    LawSpecDef,
-    law_definition,
-)
 
 if TYPE_CHECKING:
     from returns.result import Result  # noqa: WPS433
@@ -50,102 +31,15 @@ _ErrorType = TypeVar('_ErrorType')
 _FirstUnwrappableType = TypeVar('_FirstUnwrappableType')
 _SecondUnwrappableType = TypeVar('_SecondUnwrappableType')
 
-# Used in laws:
-_NewType1 = TypeVar('_NewType1')
-
-
-@final
-class _LawSpec(LawSpecDef):
-    """
-    Result laws.
-
-    We need to be sure that ``.map``, ``.bind``, ``.alt``, and ``.rescue``
-    works correctly for both success and failure types.
-    """
-
-    @law_definition
-    def map_short_circuit_law(
-        raw_value: _SecondType,
-        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
-        function: Callable[[_FirstType], _NewType1],
-    ) -> None:
-        """Ensures that you cannot map a failure."""
-        assert_equal(
-            container.from_failure(raw_value),
-            container.from_failure(raw_value).map(function),
-        )
-
-    @law_definition
-    def bind_short_circuit_law(
-        raw_value: _SecondType,
-        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
-        function: Callable[
-            [_FirstType],
-            KindN[ResultLikeN, _NewType1, _SecondType, _ThirdType],
-        ],
-    ) -> None:
-        """
-        Ensures that you cannot bind a failure.
-
-        See: https://wiki.haskell.org/Typeclassopedia#MonadFail
-        """
-        assert_equal(
-            container.from_failure(raw_value),
-            container.from_failure(raw_value).bind(function),
-        )
-
-    @law_definition
-    def alt_short_circuit_law(
-        raw_value: _SecondType,
-        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
-        function: Callable[[_SecondType], _NewType1],
-    ) -> None:
-        """Ensures that you cannot alt a success."""
-        assert_equal(
-            container.from_value(raw_value),
-            container.from_value(raw_value).alt(function),
-        )
-
-    @law_definition
-    def rescue_short_circuit_law(
-        raw_value: _FirstType,
-        container: ResultLikeN[_FirstType, _SecondType, _ThirdType],
-        function: Callable[
-            [_SecondType],
-            KindN[ResultLikeN, _FirstType, _NewType1, _ThirdType],
-        ],
-    ) -> None:
-        """Ensures that you cannot rescue a success."""
-        assert_equal(
-            container.from_value(raw_value),
-            container.from_value(raw_value).rescue(function),
-        )
-
 
 class ResultLikeN(
-    ContainerN[_FirstType, _SecondType, _ThirdType],
-    bimappable.BiMappableN[_FirstType, _SecondType, _ThirdType],
-    rescuable.RescuableN[_FirstType, _SecondType, _ThirdType],
-    Lawful['ResultLikeN[_FirstType, _SecondType, _ThirdType]'],
+    failable.DiverseFailableN[_FirstType, _SecondType, _ThirdType],
 ):
     """
     Base types for types that looks like ``Result`` but cannot be unwrapped.
 
     Like ``RequiresContextResult`` or ``FutureResult``.
     """
-
-    _laws: ClassVar[Sequence[Law]] = (
-        Law3(_LawSpec.map_short_circuit_law),
-        Law3(_LawSpec.bind_short_circuit_law),
-        Law3(_LawSpec.alt_short_circuit_law),
-        Law3(_LawSpec.rescue_short_circuit_law),
-    )
-
-    @abstractmethod
-    def swap(
-        self: _ResultLikeType,
-    ) -> KindN[_ResultLikeType, _SecondType, _FirstType, _ThirdType]:
-        """Swaps value and error types in ``Result``."""
 
     @abstractmethod
     def bind_result(
@@ -160,14 +54,6 @@ class ResultLikeN(
         cls: Type[_ResultLikeType],  # noqa: N805
         inner_value: 'Result[_ValueType, _ErrorType]',
     ) -> KindN[_ResultLikeType, _ValueType, _ErrorType, _ThirdType]:
-        """Unit method to create new containers from any raw value."""
-
-    @classmethod
-    @abstractmethod
-    def from_failure(
-        cls: Type[_ResultLikeType],  # noqa: N805
-        inner_value: _ErrorType,
-    ) -> KindN[_ResultLikeType, _FirstType, _ErrorType, _ThirdType]:
         """Unit method to create new containers from any raw value."""
 
 

--- a/returns/maybe.py
+++ b/returns/maybe.py
@@ -51,6 +51,9 @@ class Maybe(
 
     _inner_value: Optional[_ValueType]
 
+    #: Alias for `Nothing`
+    empty: ClassVar['Maybe[Any]']
+
     # These two are required for projects like `classes`:
 
     #: Success type that is used to represent the successful computation.
@@ -441,6 +444,7 @@ def Some(inner_value: _NewValueType) -> Maybe[_NewValueType]:  # noqa: N802
 
 #: Public unit value of protected :class:`~_Nothing` type.
 Nothing: Maybe[NoReturn] = _Nothing()
+Maybe.empty = Nothing
 
 
 def maybe(

--- a/returns/methods/cond.py
+++ b/returns/methods/cond.py
@@ -1,22 +1,22 @@
 from typing import Type, TypeVar
 
-from returns.interfaces.specific.result import ResultLikeN
+from returns.interfaces.failable import DiverseFailableN
 from returns.primitives.hkt import Kind2, kinded
 
 _ValueType = TypeVar('_ValueType')
 _ErrorType = TypeVar('_ErrorType')
 
-_ResultKind = TypeVar('_ResultKind', bound=ResultLikeN)
+_DiverseFailableKind = TypeVar('_DiverseFailableKind', bound=DiverseFailableN)
 
 
 def internal_cond(
-    container_type: Type[_ResultKind],
+    container_type: Type[_DiverseFailableKind],
     is_success: bool,
     success_value: _ValueType,
     error_value: _ErrorType,
-) -> Kind2[_ResultKind, _ValueType, _ErrorType]:
+) -> Kind2[_DiverseFailableKind, _ValueType, _ErrorType]:
     """
-    Help us to reduce the boilerplate when choosing paths with ``ResultLikeN``.
+    Reduce the boilerplate when choosing paths with ``DiverseFailableN``.
 
     .. code:: python
 

--- a/returns/pointfree/cond.py
+++ b/returns/pointfree/cond.py
@@ -1,22 +1,24 @@
 from typing import Callable, Type, TypeVar
 
-from returns.interfaces.specific.result import ResultLikeN
+from returns.interfaces.failable import DiverseFailableN
 from returns.methods.cond import internal_cond
 from returns.primitives.hkt import Kind2, Kinded, kinded
 
 _ValueType = TypeVar('_ValueType')
 _ErrorType = TypeVar('_ErrorType')
 
-_ResultKind = TypeVar('_ResultKind', bound=ResultLikeN)
+_DiverseFailableKind = TypeVar('_DiverseFailableKind', bound=DiverseFailableN)
 
 
 def cond(
-    container_type: Type[_ResultKind],
+    container_type: Type[_DiverseFailableKind],
     success_value: _ValueType,
     error_value: _ErrorType,
-) -> Kinded[Callable[[bool], Kind2[_ResultKind, _ValueType, _ErrorType]]]:
+) -> Kinded[
+    Callable[[bool], Kind2[_DiverseFailableKind, _ValueType, _ErrorType]]
+]:
     """
-    Help us to reduce the boilerplate when choosing paths with ``ResultLikeN``.
+    Reduce the boilerplate when choosing paths with ``DiverseFailableN``.
 
     .. code:: python
 
@@ -30,7 +32,7 @@ def cond(
     @kinded
     def factory(
         is_success: bool,
-    ) -> Kind2[_ResultKind, _ValueType, _ErrorType]:
+    ) -> Kind2[_DiverseFailableKind, _ValueType, _ErrorType]:
         return internal_cond(
             container_type, is_success, success_value, error_value,
         )

--- a/returns/pointfree/unify.py
+++ b/returns/pointfree/unify.py
@@ -1,6 +1,6 @@
 from typing import Callable, TypeVar, Union
 
-from returns.interfaces.specific.result import ResultLikeN
+from returns.interfaces.failable import DiverseFailableN
 from returns.primitives.hkt import Kind2, Kinded, kinded
 
 _ValueType = TypeVar('_ValueType')
@@ -8,17 +8,21 @@ _NewValueType = TypeVar('_NewValueType')
 _ErrorType = TypeVar('_ErrorType')
 _NewErrorType = TypeVar('_NewErrorType')
 
-_ResultLikeKind = TypeVar('_ResultLikeKind', bound=ResultLikeN)
+_DiverseFailableKind = TypeVar('_DiverseFailableKind', bound=DiverseFailableN)
 
 
 def unify(  # noqa: WPS234
     function: Callable[
-        [_ValueType], Kind2[_ResultLikeKind, _NewValueType, _NewErrorType],
+        [_ValueType], Kind2[_DiverseFailableKind, _NewValueType, _NewErrorType],
     ],
 ) -> Kinded[
     Callable[
-        [Kind2[_ResultLikeKind, _ValueType, _ErrorType]],
-        Kind2[_ResultLikeKind, _NewValueType, Union[_ErrorType, _NewErrorType]],
+        [Kind2[_DiverseFailableKind, _ValueType, _ErrorType]],
+        Kind2[
+            _DiverseFailableKind,
+            _NewValueType,
+            Union[_ErrorType, _NewErrorType],
+        ],
     ]
 ]:
     """
@@ -47,9 +51,9 @@ def unify(  # noqa: WPS234
     """
     @kinded
     def factory(
-        container: Kind2[_ResultLikeKind, _ValueType, _ErrorType],
+        container: Kind2[_DiverseFailableKind, _ValueType, _ErrorType],
     ) -> Kind2[
-        _ResultLikeKind, _NewValueType, Union[_ErrorType, _NewErrorType],
+        _DiverseFailableKind, _NewValueType, Union[_ErrorType, _NewErrorType],
     ]:
         return container.bind(function)  # type: ignore
     return factory

--- a/typesafety/test_interfaces/test_failable/test_diverse_failable.yml
+++ b/typesafety/test_interfaces/test_failable/test_diverse_failable.yml
@@ -1,0 +1,147 @@
+- case: diverse_failable_inheritance_correct2
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import DiverseFailable2
+    from returns.primitives.hkt import SupportsKind2
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+    _UpdatedType = TypeVar('_UpdatedType')
+
+    class MyClass(
+        SupportsKind2['MyClass', _FirstType, _SecondType],
+        DiverseFailable2[_FirstType, _SecondType],
+    ):
+        def swap(self) -> MyClass[_SecondType, _FirstType]:
+            ...
+
+        @classmethod
+        def from_failure(
+            cls,
+            inner_value: _UpdatedType
+        ) -> MyClass[_FirstType, _UpdatedType]:
+            ...
+
+    x: MyClass[str, int]
+    reveal_type(x.swap())  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.str*]'
+    reveal_type(MyClass.from_failure(10))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.int*]'
+
+
+- case: diverse_failable_inheritance_correct3
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import DiverseFailable3
+    from returns.primitives.hkt import SupportsKind3
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+    _ThirdType = TypeVar('_ThirdType')
+    _UpdatedType = TypeVar('_UpdatedType')
+
+    class MyClass(
+        SupportsKind3['MyClass', _FirstType, _SecondType, _ThirdType],
+        DiverseFailable3[_FirstType, _SecondType, _ThirdType],
+    ):
+        def swap(self) -> MyClass[_SecondType, _FirstType, _ThirdType]:
+            ...
+
+        @classmethod
+        def from_failure(
+            cls,
+            inner_value: _UpdatedType
+        ) -> MyClass[_FirstType, _UpdatedType, _ThirdType]:
+            ...
+
+    x: MyClass[float, bool, str]
+    reveal_type(x.swap())  # N: Revealed type is 'main.MyClass[builtins.bool*, builtins.float*, builtins.str*]'
+    reveal_type(MyClass.from_failure(10))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.int*, <nothing>]'
+
+
+- case: diverse_failable_inheritance_missing
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from typing_extensions import final
+    from returns.interfaces.failable import DiverseFailable2
+    from returns.primitives.hkt import SupportsKind2
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+
+    @final
+    class MyClass(
+        SupportsKind2['MyClass', _FirstType, _SecondType],
+        DiverseFailable2[_FirstType, _SecondType],
+    ):
+        ...
+  out: |
+    main:10: error: Final class main.MyClass has abstract attributes "alt", "apply", "bind", "from_failure", "from_iterable", "from_value", "map", "rescue", "swap"
+
+
+- case: diverse_failable_inheritance_wrong2
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import DiverseFailable2
+    from returns.primitives.hkt import SupportsKind2
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+
+    class MyClass(
+        SupportsKind2['MyClass', _FirstType, _SecondType],
+        DiverseFailable2[_FirstType, _SecondType],
+    ):
+        def swap(self) -> MyClass[_FirstType, _SecondType]:
+            ...
+
+        @classmethod
+        def from_failure(
+            cls,
+            inner_value: _FirstType
+        ) -> MyClass[_FirstType, _FirstType]:
+            ...
+
+    x: MyClass[str, int]
+  out: |
+    main:12: error: Return type "MyClass[_FirstType, _SecondType]" of "swap" incompatible with return type "KindN[MyClass[_FirstType, _SecondType], _SecondType, _FirstType, NoReturn]" in supertype "DiverseFailableN"
+    main:16: error: Argument 1 of "from_failure" is incompatible with supertype "DiverseFailableN"; supertype defines the argument type as "_UpdatedType"
+    main:16: error: Return type "MyClass[_FirstType, _FirstType]" of "from_failure" incompatible with return type "KindN[MyClass[_FirstType, _SecondType], _FirstType, _UpdatedType, NoReturn]" in supertype "DiverseFailableN"
+    main:16: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+    main:16: note: This violates the Liskov substitution principle
+
+
+- case: diverse_failable_inheritance_wrong3
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import DiverseFailable3
+    from returns.primitives.hkt import SupportsKind3
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+    _ThirdType = TypeVar('_ThirdType')
+
+    class MyClass(
+        SupportsKind3['MyClass', _FirstType, _SecondType, _ThirdType],
+        DiverseFailable3[_FirstType, _SecondType, _ThirdType],
+    ):
+        def swap(self) -> MyClass[_FirstType, _SecondType, _ThirdType]:
+            ...
+
+        @classmethod
+        def from_failure(
+            cls,
+            inner_value: _SecondType
+        ) -> MyClass[_FirstType, _FirstType, _FirstType]:
+            ...
+
+    x: MyClass[float, bool, str]
+  out: |
+    main:13: error: Return type "MyClass[_FirstType, _SecondType, _ThirdType]" of "swap" incompatible with return type "KindN[MyClass[_FirstType, _SecondType, _ThirdType], _SecondType, _FirstType, _ThirdType]" in supertype "DiverseFailableN"
+    main:17: error: Argument 1 of "from_failure" is incompatible with supertype "DiverseFailableN"; supertype defines the argument type as "_UpdatedType"
+    main:17: error: Return type "MyClass[_FirstType, _FirstType, _FirstType]" of "from_failure" incompatible with return type "KindN[MyClass[_FirstType, _SecondType, _ThirdType], _FirstType, _UpdatedType, _ThirdType]" in supertype "DiverseFailableN"
+    main:17: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+    main:17: note: This violates the Liskov substitution principle

--- a/typesafety/test_interfaces/test_failable/test_failable.yml
+++ b/typesafety/test_interfaces/test_failable/test_failable.yml
@@ -1,0 +1,54 @@
+- case: failable_inheritance_correct2
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import Failable2
+    from returns.primitives.hkt import SupportsKind2
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+
+    class MyClass(
+        SupportsKind2['MyClass', _FirstType, _SecondType],
+        Failable2[_FirstType, _SecondType],
+    ):
+        ...
+
+
+- case: failable_inheritance_correct3
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import Failable3
+    from returns.primitives.hkt import SupportsKind3
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+    _ThirdType = TypeVar('_ThirdType')
+
+    class MyClass(
+        SupportsKind3['MyClass', _FirstType, _SecondType, _ThirdType],
+        Failable3[_FirstType, _SecondType, _ThirdType],
+    ):
+        ...
+
+
+- case: failable_inheritance_missing
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from typing_extensions import final
+    from returns.interfaces.failable import Failable2
+    from returns.primitives.hkt import SupportsKind2
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+
+    @final
+    class MyClass(
+        SupportsKind2['MyClass', _FirstType, _SecondType],
+        Failable2[_FirstType, _SecondType],
+    ):
+        ...
+  out: |
+    main:10: error: Final class main.MyClass has abstract attributes "apply", "bind", "from_iterable", "from_value", "map", "rescue"

--- a/typesafety/test_interfaces/test_failable/test_single_failable.yml
+++ b/typesafety/test_interfaces/test_failable/test_single_failable.yml
@@ -1,0 +1,54 @@
+- case: single_failable_inheritance_correct2
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import SingleFailable2
+    from returns.primitives.hkt import SupportsKind2
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+
+    class MyClass(
+        SupportsKind2['MyClass', _FirstType, _SecondType],
+        SingleFailable2[_FirstType, _SecondType],
+    ):
+        ...
+
+
+- case: single_failable_inheretance_correct3
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from returns.interfaces.failable import SingleFailable3
+    from returns.primitives.hkt import SupportsKind3
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+    _ThirdType = TypeVar('_ThirdType')
+
+    class MyClass(
+        SupportsKind3['MyClass', _FirstType, _SecondType, _ThirdType],
+        SingleFailable3[_FirstType, _SecondType, _ThirdType],
+    ):
+        ...
+
+
+- case: single_failable_inheritance_missing
+  disable_cache: false
+  main: |
+    from typing import TypeVar
+    from typing_extensions import final
+    from returns.interfaces.failable import SingleFailable2
+    from returns.primitives.hkt import SupportsKind2
+
+    _FirstType = TypeVar('_FirstType')
+    _SecondType = TypeVar('_SecondType')
+
+    @final
+    class MyClass(
+        SupportsKind2['MyClass', _FirstType, _SecondType],
+        SingleFailable2[_FirstType, _SecondType],
+    ):
+        ...
+  out: |
+    main:10: error: Final class main.MyClass has abstract attributes "apply", "bind", "empty", "from_iterable", "from_value", "map", "rescue"

--- a/typesafety/test_interfaces/test_specific/test_maybe/test_maybe_based.yml
+++ b/typesafety/test_interfaces/test_specific/test_maybe/test_maybe_based.yml
@@ -30,7 +30,7 @@
     class MyClass(SupportsKind2['MyClass', V, None], MaybeBased2[V, None]):
         ...
   out: |
-    main:9: error: Final class main.MyClass has abstract attributes "apply", "bind", "bind_optional", "equals", "failure", "from_iterable", "from_optional", "from_value", "map", "or_else_call", "rescue", "unwrap"
+    main:9: error: Final class main.MyClass has abstract attributes "apply", "bind", "bind_optional", "empty", "equals", "failure", "from_iterable", "from_optional", "from_value", "map", "or_else_call", "rescue", "unwrap"
 
 
 - case: maybe_based_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_maybe/test_maybe_like.yml
+++ b/typesafety/test_interfaces/test_specific/test_maybe/test_maybe_like.yml
@@ -34,7 +34,7 @@
     class MyClass(SupportsKind2['MyClass', V, None], MaybeLike2[V, None]):
         ...
   out: |
-    main:9: error: Final class main.MyClass has abstract attributes "apply", "bind", "bind_optional", "from_iterable", "from_optional", "from_value", "map", "rescue"
+    main:9: error: Final class main.MyClass has abstract attributes "apply", "bind", "bind_optional", "empty", "from_iterable", "from_optional", "from_value", "map", "rescue"
 
 
 - case: maybe_like_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_result/test_resultlike_inheritance.yml
+++ b/typesafety/test_interfaces/test_specific/test_result/test_resultlike_inheritance.yml
@@ -17,9 +17,6 @@
         SupportsKind2['MyClass', _ValueType, _ErrorType],
         ResultLike2[_ValueType, _ErrorType],
     ):
-        def swap(self) -> MyClass[_ErrorType, _ValueType]:
-            ...
-
         def bind_result(
             self,
             function: Callable[
@@ -33,12 +30,6 @@
         def from_result(
             self, inner_value: Result[_NewValueType, _NewErrorType],
         ) -> MyClass[_NewValueType, _NewErrorType]:
-            ...
-
-        @classmethod
-        def from_failure(
-            cls, inner_value: _NewErrorType,
-        ) -> MyClass[Any, _NewErrorType]:
             ...
 
     def test(a: int) -> Result[float, str]:
@@ -68,9 +59,6 @@
         SupportsKind3['MyClass', _ValueType, _ErrorType, _T],
         ResultLike3[_ValueType, _ErrorType, _T],
     ):
-        def swap(self) -> MyClass[_ErrorType, _ValueType, _T]:
-            ...
-
         def bind_result(
             self,
             function: Callable[
@@ -84,12 +72,6 @@
         def from_result(
             self, inner_value: Result[_NewValueType, _NewErrorType],
         ) -> MyClass[_NewValueType, _NewErrorType, Any]:
-            ...
-
-        @classmethod
-        def from_failure(
-            cls, inner_value: _NewErrorType,
-        ) -> MyClass[Any, _NewErrorType, Any]:
             ...
 
     def test(a: int) -> Result[float, str]:
@@ -136,9 +118,6 @@
         SupportsKind2['MyClass', _ValueType, _ErrorType],
         ResultLike2[_ValueType, _ErrorType],
     ):
-        def swap(self) -> MyClass[_ValueType, _ErrorType]:
-            ...
-
         def bind_result(
             self,
             function: Callable[
@@ -152,20 +131,12 @@
             self, inner_value: Result[_NewValueType, _NewErrorType],
         ) -> MyClass[_NewValueType, _NewErrorType]:
             ...
-
-        @classmethod
-        def from_failure(
-            cls, inner_value: _NewErrorType,
-        ) -> MyClass[_NewErrorType, _NewErrorType]:
-            ...
   out: |
-    main:17: error: Return type "MyClass[_ValueType, _ErrorType]" of "swap" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType], _ErrorType, _ValueType, NoReturn]" in supertype "ResultLikeN"
-    main:20: error: Argument 1 of "bind_result" is incompatible with supertype "ResultLikeN"; supertype defines the argument type as "Callable[[_ValueType], Result[_UpdatedType, _ErrorType]]"
-    main:20: error: Return type "MyClass[_ValueType, _ErrorType]" of "bind_result" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType], _UpdatedType, _ErrorType, NoReturn]" in supertype "ResultLikeN"
-    main:20: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
-    main:20: note: This violates the Liskov substitution principle
-    main:29: error: Signature of "from_result" incompatible with supertype "ResultLikeN"
-    main:35: error: Signature of "from_failure" incompatible with supertype "ResultLikeN"
+    main:17: error: Argument 1 of "bind_result" is incompatible with supertype "ResultLikeN"; supertype defines the argument type as "Callable[[_ValueType], Result[_UpdatedType, _ErrorType]]"
+    main:17: error: Return type "MyClass[_ValueType, _ErrorType]" of "bind_result" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType], _UpdatedType, _ErrorType, NoReturn]" in supertype "ResultLikeN"
+    main:17: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+    main:17: note: This violates the Liskov substitution principle
+    main:26: error: Signature of "from_result" incompatible with supertype "ResultLikeN"
 
 
 - case: result_inheritance_wrong3
@@ -188,9 +159,6 @@
         SupportsKind3['MyClass', _ValueType, _ErrorType, _T],
         ResultLike3[_ValueType, _ErrorType, _T],
     ):
-        def swap(self) -> MyClass[_ErrorType, _ValueType, int]:
-            ...
-
         def bind_result(
             self,
             function: Callable[
@@ -205,14 +173,6 @@
             self, inner_value: Result[_NewValueType, _NewErrorType],
         ) -> MyClass[_NewValueType, _NewErrorType, bool]:
             ...
-
-        @classmethod
-        def from_failure(
-            cls, inner_value: _NewErrorType,
-        ) -> MyClass[Any, _NewErrorType, Exception]:
-            ...
   out: |
-    main:18: error: Return type "MyClass[_ErrorType, _ValueType, int]" of "swap" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType, _T], _ErrorType, _ValueType, _T]" in supertype "ResultLikeN"
-    main:21: error: Return type "MyClass[_NewValueType, _ErrorType, str]" of "bind_result" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType, _T], _UpdatedType, _ErrorType, _T]" in supertype "ResultLikeN"
-    main:31: error: Return type "MyClass[_NewValueType, _NewErrorType, bool]" of "from_result" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType, _T], _ValueType, _ErrorType, _T]" in supertype "ResultLikeN"
-    main:37: error: Return type "MyClass[Any, _NewErrorType, Exception]" of "from_failure" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType, _T], _ValueType, _ErrorType, _T]" in supertype "ResultLikeN"
+    main:18: error: Return type "MyClass[_NewValueType, _ErrorType, str]" of "bind_result" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType, _T], _UpdatedType, _ErrorType, _T]" in supertype "ResultLikeN"
+    main:28: error: Return type "MyClass[_NewValueType, _NewErrorType, bool]" of "from_result" incompatible with return type "KindN[MyClass[_ValueType, _ErrorType, _T], _ValueType, _ErrorType, _T]" in supertype "ResultLikeN"


### PR DESCRIPTION
# Creates `failable` interfaces

Instead of have just one `LawSpec` I've made two:
* `_FailableLawSpec` for `FailableN` interface
* `_DiverseFailableLawSpec` for `DiverseFailableN` interface

Please see if the tests are enough, I made based on `ResultLikeN` tests!

I don't find where I have to modify the docs, I've add the API reference, is this?

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`: Already has the entry (Adds new public interfaces: see `returns.interfaces`)

### Feature related

- [X] We need to create a new `interfaces.failable` module, we would define two types there
- [X] First type would be `Failable` that extends both `ContainerN` and `Rescueable`. This type is supposed to have only a single failed value
- [X] Second type would be `DiverseFailable` that extends both `Failable` and `BiMappable`. The thing here is that some types can only fail with one value: `None`, `0`, `False`, `NaN`, you name it. But, other types can fail with literally any value: like `Result` does. So, some types just don't need `.alt` and `.from_failure` methods
- [X] We need to move `swap` and `.from_failure` from `ResultLikeN` to `DiverseFailable` type
- [X] Type test all the things!
- [X] Change docs where we already cover this

## Related issues

Closes #623
