### PR TITLE
Modifies `cond` and `unify` to use `KindN` instead of `Kind2`

### DIFF
--- a/returns/methods/cond.py
+++ b/returns/methods/cond.py
@@ -1,7 +1,8 @@
 from typing import Type, TypeVar
 
+from returns.context import NoDeps
 from returns.interfaces.failable import DiverseFailableN
-from returns.primitives.hkt import Kind2, kinded
+from returns.primitives.hkt import KindN, kinded
 
 _ValueType = TypeVar('_ValueType')
 _ErrorType = TypeVar('_ErrorType')
@@ -14,7 +15,7 @@ def internal_cond(
     is_success: bool,
     success_value: _ValueType,
     error_value: _ErrorType,
-) -> Kind2[_DiverseFailableKind, _ValueType, _ErrorType]:
+) -> KindN[_DiverseFailableKind, _ValueType, _ErrorType, NoDeps]:
     """
     Reduce the boilerplate when choosing paths with ``DiverseFailableN``.
 

--- a/returns/pointfree/cond.py
+++ b/returns/pointfree/cond.py
@@ -1,8 +1,9 @@
 from typing import Callable, Type, TypeVar
 
+from returns.context import NoDeps
 from returns.interfaces.failable import DiverseFailableN
 from returns.methods.cond import internal_cond
-from returns.primitives.hkt import Kind2, Kinded, kinded
+from returns.primitives.hkt import Kinded, KindN, kinded
 
 _ValueType = TypeVar('_ValueType')
 _ErrorType = TypeVar('_ErrorType')
@@ -15,7 +16,9 @@ def cond(
     success_value: _ValueType,
     error_value: _ErrorType,
 ) -> Kinded[
-    Callable[[bool], Kind2[_DiverseFailableKind, _ValueType, _ErrorType]]
+    Callable[
+        [bool], KindN[_DiverseFailableKind, _ValueType, _ErrorType, NoDeps],
+    ],
 ]:
     """
     Reduce the boilerplate when choosing paths with ``DiverseFailableN``.
@@ -32,7 +35,7 @@ def cond(
     @kinded
     def factory(
         is_success: bool,
-    ) -> Kind2[_DiverseFailableKind, _ValueType, _ErrorType]:
+    ) -> KindN[_DiverseFailableKind, _ValueType, _ErrorType, NoDeps]:
         return internal_cond(
             container_type, is_success, success_value, error_value,
         )

--- a/returns/pointfree/unify.py
+++ b/returns/pointfree/unify.py
@@ -1,27 +1,33 @@
 from typing import Callable, TypeVar, Union
 
 from returns.interfaces.failable import DiverseFailableN
-from returns.primitives.hkt import Kind2, Kinded, kinded
+from returns.primitives.hkt import Kinded, KindN, kinded
 
-_ValueType = TypeVar('_ValueType')
-_NewValueType = TypeVar('_NewValueType')
-_ErrorType = TypeVar('_ErrorType')
-_NewErrorType = TypeVar('_NewErrorType')
+_FirstType = TypeVar('_FirstType')
+_NewFirstType = TypeVar('_NewFirstType')
+_SecondType = TypeVar('_SecondType')
+_NewSecondType = TypeVar('_NewSecondType')
+_ThirdType = TypeVar('_ThirdType')
+_NewThirdType = TypeVar('_NewThirdType')
 
 _DiverseFailableKind = TypeVar('_DiverseFailableKind', bound=DiverseFailableN)
 
 
 def unify(  # noqa: WPS234
     function: Callable[
-        [_ValueType], Kind2[_DiverseFailableKind, _NewValueType, _NewErrorType],
+        [_FirstType],
+        KindN[
+            _DiverseFailableKind, _NewFirstType, _NewSecondType, _NewThirdType,
+        ],
     ],
 ) -> Kinded[
     Callable[
-        [Kind2[_DiverseFailableKind, _ValueType, _ErrorType]],
-        Kind2[
+        [KindN[_DiverseFailableKind, _FirstType, _SecondType, _ThirdType]],
+        KindN[
             _DiverseFailableKind,
-            _NewValueType,
-            Union[_ErrorType, _NewErrorType],
+            _NewFirstType,
+            Union[_SecondType, _NewSecondType],
+            _NewThirdType,
         ],
     ]
 ]:
@@ -51,9 +57,14 @@ def unify(  # noqa: WPS234
     """
     @kinded
     def factory(
-        container: Kind2[_DiverseFailableKind, _ValueType, _ErrorType],
-    ) -> Kind2[
-        _DiverseFailableKind, _NewValueType, Union[_ErrorType, _NewErrorType],
+        container: KindN[
+            _DiverseFailableKind, _FirstType, _SecondType, _ThirdType,
+        ],
+    ) -> KindN[
+        _DiverseFailableKind,
+        _NewFirstType,
+        Union[_SecondType, _NewSecondType],
+        _NewThirdType,
     ]:
         return container.bind(function)  # type: ignore
     return factory

--- a/typesafety/test_pointfree/test_unify.yml
+++ b/typesafety/test_pointfree/test_unify.yml
@@ -47,10 +47,10 @@
         ...
 
     x: ReaderIOResult[float, Exception, float]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool, Union[builtins.Exception*, builtins.str], Any]'
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool, Union[builtins.Exception*, builtins.str], builtins.float]'
 
 
-- case: unify_reader_future_result
+- case: unify_reader_future_result1
   disable_cache: false
   main: |
     from returns.pointfree import unify
@@ -60,7 +60,20 @@
         ...
 
     x: ReaderFutureResult[int, str, NoDeps]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str*, builtins.bool], Any]'
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str*, builtins.bool], builtins.bool]'
+
+
+- case: unify_reader_future_result2
+  disable_cache: false
+  main: |
+    from returns.pointfree import unify
+    from returns.context import ReaderFutureResult
+
+    def test(arg: int) -> ReaderFutureResult[int, bool, float]:
+        ...
+
+    x: ReaderFutureResult[int, str, float]
+    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str*, builtins.bool], builtins.float]'
 
 
 - case: unify_custom_type


### PR DESCRIPTION
# Modifies `cond` and `unify` to use `KindN` instead of `Kind2`

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made

## Related issues

Closes #637 