### PR TITLE
Allows `cond` HKT method & pointfree to work with `SingleFailableN`

### DIFF
--- a/docs/pages/pointfree.rst
+++ b/docs/pages/pointfree.rst
@@ -218,8 +218,9 @@ kind of manipulation.
 cond
 ----
 
-Sometimes we need to create ``DiverseFailableN`` containers
-(e.g. ``ResultLikeN``) based on a boolean expression, ``cond`` can help us.
+Sometimes we need to create ``SingleFailableN`` or ``DiverseFailableN``
+containers (e.g. ``Maybe``, ``ResultLikeN``) based on a boolean expression,
+``cond`` can help us.
 
 See the example below:
 
@@ -227,7 +228,7 @@ See the example below:
 
   >>> from returns.pipeline import flow
   >>> from returns.pointfree import cond
-  >>> from returns.result import Failure, Success
+  >>> from returns.result import Result, Failure, Success
 
   >>> def returns_boolean(arg: int) -> bool:
   ...     return bool(arg)
@@ -241,6 +242,24 @@ See the example below:
   ...     returns_boolean(0),
   ...     cond(Result, 'success', 'failure')
   ... ) == Failure('failure')
+
+Example using ``cond`` with the ``Maybe`` container:
+
+.. code:: python
+
+  >>> from returns.pipeline import flow
+  >>> from returns.pointfree import cond
+  >>> from returns.maybe import Maybe, Some, Nothing
+
+  >>> assert flow(
+  ...     returns_boolean(1),
+  ...     cond(Maybe, 'success')
+  ... ) == Some('success')
+
+  >>> assert flow(
+  ...     returns_boolean(0),
+  ...     cond(Maybe, 'success')
+  ... ) == Nothing
 
 
 Further reading

--- a/docs/pages/pointfree.rst
+++ b/docs/pages/pointfree.rst
@@ -222,6 +222,8 @@ Sometimes we need to create ``SingleFailableN`` or ``DiverseFailableN``
 containers (e.g. ``Maybe``, ``ResultLikeN``) based on a boolean expression,
 ``cond`` can help us.
 
+Consider ``cond`` to be a functional ``if``.
+
 See the example below:
 
 .. code:: python

--- a/returns/methods/cond.py
+++ b/returns/methods/cond.py
@@ -1,23 +1,50 @@
-from typing import Type, TypeVar
+from typing import Optional, Type, TypeVar, Union, overload
 
 from returns.context import NoDeps
-from returns.interfaces.failable import DiverseFailableN
+from returns.interfaces.failable import DiverseFailableN, SingleFailableN
 from returns.primitives.hkt import KindN, kinded
 
 _ValueType = TypeVar('_ValueType')
 _ErrorType = TypeVar('_ErrorType')
 
+_SingleFailableKind = TypeVar('_SingleFailableKind', bound=SingleFailableN)
 _DiverseFailableKind = TypeVar('_DiverseFailableKind', bound=DiverseFailableN)
 
 
+@overload
+def internal_cond(
+    container_type: Type[_SingleFailableKind],
+    is_success: bool,
+    success_value: _ValueType,
+) -> KindN[_SingleFailableKind, _ValueType, _ErrorType, NoDeps]:
+    """Reduce the boilerplate when choosing paths with ``SingleFailableN``."""
+
+
+@overload
 def internal_cond(
     container_type: Type[_DiverseFailableKind],
     is_success: bool,
     success_value: _ValueType,
     error_value: _ErrorType,
 ) -> KindN[_DiverseFailableKind, _ValueType, _ErrorType, NoDeps]:
+    """Reduce the boilerplate when choosing paths with ``DiverseFailableN``."""
+
+
+def internal_cond(  # type: ignore
+    container_type: Union[
+        Type[_SingleFailableKind], Type[_DiverseFailableKind],
+    ],
+    is_success: bool,
+    success_value: _ValueType,
+    error_value: Optional[_ErrorType] = None,
+):
     """
-    Reduce the boilerplate when choosing paths with ``DiverseFailableN``.
+    Reduce the boilerplate when choosing paths.
+
+    Works with ``SingleFailableN`` (e.g. ``Maybe``)
+    and ``DiverseFailableN`` (e.g. ``Result``).
+
+    Example using ``cond`` with the ``Result`` container:
 
     .. code:: python
 
@@ -35,10 +62,25 @@ def internal_cond(
       >>> assert is_numeric('42') == Success('It is a number')
       >>> assert is_numeric('non numeric') == Failure('It is not a number')
 
+    Example using ``cond`` with the ``Maybe`` container:
+
+    .. code:: python
+
+      >>> from returns.maybe import Maybe, Some, Nothing
+
+      >>> def is_positive(number: int) -> Maybe[int]:
+      ...     return cond(Maybe, number > 0, number)
+
+      >>> assert is_positive(10) == Some(10)
+      >>> assert is_positive(-10) == Nothing
+
     """
     if is_success:
         return container_type.from_value(success_value)
-    return container_type.from_failure(error_value)
+
+    if issubclass(container_type, DiverseFailableN):
+        return container_type.from_failure(error_value)
+    return container_type.empty  # type: ignore
 
 
 #: Kinded version of :func:`~internal_cond`, use it to infer real return type.

--- a/returns/pointfree/cond.py
+++ b/returns/pointfree/cond.py
@@ -1,7 +1,7 @@
-from typing import Callable, Type, TypeVar
+from typing import Callable, Optional, Type, TypeVar, Union, overload
 
 from returns.context import NoDeps
-from returns.interfaces.failable import DiverseFailableN
+from returns.interfaces.failable import DiverseFailableN, SingleFailableN
 from returns.methods.cond import internal_cond
 from returns.primitives.hkt import Kinded, KindN, kinded
 
@@ -9,8 +9,22 @@ _ValueType = TypeVar('_ValueType')
 _ErrorType = TypeVar('_ErrorType')
 
 _DiverseFailableKind = TypeVar('_DiverseFailableKind', bound=DiverseFailableN)
+_SingleFailableKind = TypeVar('_SingleFailableKind', bound=SingleFailableN)
 
 
+@overload
+def cond(
+    container_type: Type[_SingleFailableKind],
+    success_value: _ValueType,
+) -> Kinded[
+    Callable[
+        [bool], KindN[_SingleFailableKind, _ValueType, _ErrorType, NoDeps],
+    ]
+]:
+    """Reduce the boilerplate when choosing paths with ``SingleFailableN``."""
+
+
+@overload
 def cond(
     container_type: Type[_DiverseFailableKind],
     success_value: _ValueType,
@@ -18,10 +32,25 @@ def cond(
 ) -> Kinded[
     Callable[
         [bool], KindN[_DiverseFailableKind, _ValueType, _ErrorType, NoDeps],
-    ],
+    ]
 ]:
+    """Reduce the boilerplate when choosing paths with ``DiverseFailableN``."""
+
+
+def cond(  # type: ignore
+    container_type: Union[
+        Type[_SingleFailableKind], Type[_DiverseFailableKind],
+    ],
+    success_value: _ValueType,
+    error_value: Optional[_ErrorType] = None,
+):
     """
-    Reduce the boilerplate when choosing paths with ``DiverseFailableN``.
+    Reduce the boilerplate when choosing paths.
+
+    Works with ``SingleFailableN`` (e.g. ``Maybe``)
+    and ``DiverseFailableN`` (e.g. ``Result``).
+
+    Example using ``cond`` with the ``Result`` container:
 
     .. code:: python
 
@@ -31,11 +60,20 @@ def cond(
       >>> assert cond(Result, 'success', 'failure')(True) == Success('success')
       >>> assert cond(Result, 'success', 'failure')(False) == Failure('failure')
 
+    Example using ``cond`` with the ``Maybe`` container:
+
+    .. code:: python
+
+      >>> from returns.maybe import Maybe, Some, Nothing
+
+      >>> assert cond(Maybe, 10.0)(True) == Some(10.0)
+      >>> assert cond(Maybe, 10.0)(False) == Nothing
+
     """
     @kinded
     def factory(
         is_success: bool,
-    ) -> KindN[_DiverseFailableKind, _ValueType, _ErrorType, NoDeps]:
+    ):
         return internal_cond(
             container_type, is_success, success_value, error_value,
         )

--- a/typesafety/test_methods/test_cond.yml
+++ b/typesafety/test_methods/test_cond.yml
@@ -52,6 +52,15 @@
     reveal_type(cond(ReaderFutureResult, True, 1, 1.0))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult*[builtins.int*, builtins.float*, Any]'
 
 
+- case: cond_maybe
+  disable_cache: false
+  main: |
+    from returns.methods import cond
+    from returns.maybe import Maybe
+
+    reveal_type(cond(Maybe, True, 'test'))  # N: Revealed type is 'returns.maybe.Maybe*[builtins.str*]'
+
+
 - case: cond_custom_type
   disable_cache: false
   main: |

--- a/typesafety/test_pointfree/test_cond.yml
+++ b/typesafety/test_pointfree/test_cond.yml
@@ -43,6 +43,15 @@
     reveal_type(cond(ReaderFutureResult, 1, 1.0)(True))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult*[builtins.int*, builtins.float*, Any]'
 
 
+- case: cond_maybe
+  disable_cache: false
+  main: |
+    from returns.pointfree import cond
+    from returns.maybe import Maybe
+
+    reveal_type(cond(Maybe, True)(False))  # N: Revealed type is 'returns.maybe.Maybe[builtins.bool]'
+
+
 - case: cond_custom_type
   disable_cache: false
   main: |


### PR DESCRIPTION
# Allows `cond` HKT method & pointfree to work with `SingleFailableN`

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made

## Related issues

Closes #634
