### PR TITLE
Renames property `empty` to `no_args` of `ReaderLike2` and `ReaderLike3` interfaces 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ See [0Ver](https://0ver.org/).
 - **Breaking**: Removes ``.from_iterable`` method from all containers,
   instead adds better `iterables` support,
   we now have `returns.iterables` module with `Fold` helper
+- **Breaking**: Renames property `empty` to `no_args` of
+  all `RequiresContext`-based classes
 
 - Adds new public interfaces: see `returns.interfaces`
 - Adds `methods` package with several helpful things inside

--- a/returns/context/requires_context.py
+++ b/returns/context/requires_context.py
@@ -81,7 +81,7 @@ class RequiresContext(
     _inner_value: Callable[[RequiresContext, _EnvType], _ReturnType]
 
     #: A convenient placeholder to call methods created by `.from_value()`:
-    empty: ClassVar[NoDeps] = object()
+    no_args: ClassVar[NoDeps] = object()
 
     def __init__(
         self,
@@ -319,14 +319,14 @@ class RequiresContext(
 
         Consider this method as some kind of factory.
         Passed value will be a return type.
-        Make sure to use :attr:`~RequiresContext.empty`
+        Make sure to use :attr:`~RequiresContext.no_args`
         for getting the unit value.
 
         .. code:: python
 
           >>> from returns.context import RequiresContext
           >>> unit = RequiresContext.from_value(5)
-          >>> assert unit(RequiresContext.empty) == 5
+          >>> assert unit(RequiresContext.no_args) == 5
 
         Might be used with or without direct type hint.
         """
@@ -424,7 +424,7 @@ class RequiresContext(
           ...    RequiresContextFutureResult.from_value(1),
           ... )
           >>> assert anyio.run(
-          ...     container, RequiresContext.empty,
+          ...     container, RequiresContext.no_args,
           ... ) == IOSuccess(1)
 
         Can be reverted with ``RequiresContextFutureResult.from_typecast``.

--- a/returns/context/requires_context_future_result.py
+++ b/returns/context/requires_context_future_result.py
@@ -104,7 +104,7 @@ class RequiresContextFutureResult(
     ]
 
     #: A convenient placeholder to call methods created by `.from_value()`.
-    empty: ClassVar[NoDeps] = object()
+    no_args: ClassVar[NoDeps] = object()
 
     def __init__(
         self,
@@ -237,14 +237,14 @@ class RequiresContextFutureResult(
           ...    RequiresContextFutureResult.from_value('a').apply(
           ...        RequiresContextFutureResult.from_value(transform),
           ...    ),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOSuccess('ab')
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_failure('a').apply(
           ...        RequiresContextFutureResult.from_value(transform),
           ...    ),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOFailure('a')
 
         """
@@ -336,13 +336,13 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).bind_async(
           ...        function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_failure(1).bind_async(
           ...        function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -380,14 +380,14 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).bind_awaitable(
           ...         coroutine,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_failure(1).bind_awaitable(
           ...         coroutine,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -416,14 +416,14 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).bind_result(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_failure(':(').bind_result(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(':(')
 
         """
@@ -574,12 +574,12 @@ class RequiresContextFutureResult(
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_value(1).bind_io(do_io),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess('1')
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_failure(1).bind_io(do_io),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -607,14 +607,14 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).bind_ioresult(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_failure(':(').bind_ioresult(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(':(')
 
         """
@@ -643,13 +643,13 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).bind_future(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
 
           >>> failed = RequiresContextFutureResult.from_failure(':(')
           >>> assert anyio.run(
           ...     failed.bind_future(function),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(':(')
 
         """
@@ -681,13 +681,13 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).bind_future_result(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
 
           >>> failed = RequiresContextFutureResult.from_failure(':(')
           >>> assert anyio.run(
           ...     failed.bind_future_result(function),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(':(')
 
         """
@@ -716,13 +716,13 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).bind_async_future(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
 
           >>> failed = RequiresContextFutureResult.from_failure(':(')
           >>> assert anyio.run(
           ...     failed.bind_async_future(function),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(':(')
 
         """
@@ -756,13 +756,13 @@ class RequiresContextFutureResult(
           ...     ).bind_async_future_result(
           ...         function,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(2)
 
           >>> failed = RequiresContextFutureResult.from_failure(':(')
           >>> assert anyio.run(
           ...     failed.bind_async_future_result(function),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(':(')
 
         """
@@ -786,14 +786,14 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_value(1).alt(
           ...        lambda x: x + 1,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_failure(1).alt(
           ...        lambda x: x + 1,
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(2)
 
         """
@@ -886,10 +886,10 @@ class RequiresContextFutureResult(
           >>> failure = ReaderFutureResult.from_failure(-1)
 
           >>> assert anyio.run(
-          ...     success.compose_result(count), ReaderFutureResult.empty,
+          ...     success.compose_result(count), ReaderFutureResult.no_args,
           ... ) == IOSuccess(2)
           >>> assert anyio.run(
-          ...     failure.compose_result(count), ReaderFutureResult.empty,
+          ...     failure.compose_result(count), ReaderFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -973,12 +973,12 @@ class RequiresContextFutureResult(
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_result(Success(1)),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_result(Failure(1)),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1002,7 +1002,7 @@ class RequiresContextFutureResult(
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_io(IO(1)),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
         """
@@ -1026,7 +1026,7 @@ class RequiresContextFutureResult(
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_failed_io(IO(1)),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1049,12 +1049,12 @@ class RequiresContextFutureResult(
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_ioresult(IOSuccess(1)),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_ioresult(IOFailure(1)),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1079,7 +1079,7 @@ class RequiresContextFutureResult(
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_future(Future.from_value(1)),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
         """
@@ -1106,7 +1106,7 @@ class RequiresContextFutureResult(
           ...    RequiresContextFutureResult.from_failed_future(
           ...        Future.from_value(1),
           ...    ),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1133,14 +1133,14 @@ class RequiresContextFutureResult(
           ...    RequiresContextFutureResult.from_future_result_context(
           ...        RequiresContextFutureResult.from_value(1),
           ...    ),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_future_result_context(
           ...        RequiresContextFutureResult.from_failure(1),
           ...    ),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1165,14 +1165,14 @@ class RequiresContextFutureResult(
           ...    RequiresContextFutureResult.from_future_result(
           ...        FutureResult.from_value(1),
           ...    ),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...    RequiresContextFutureResult.from_future_result(
           ...        FutureResult.from_failure(1),
           ...    ),
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1203,14 +1203,14 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_typecast(
           ...         RequiresContext.from_value(FutureResult.from_value(1)),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_typecast(
           ...         RequiresContext.from_value(FutureResult.from_failure(1)),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1233,7 +1233,7 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_context(
           ...         RequiresContext.from_value(1),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
         """
@@ -1258,7 +1258,7 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_failed_context(
           ...         RequiresContext.from_value(1),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1285,14 +1285,14 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_result_context(
           ...         RequiresContextResult.from_value(1),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_result_context(
           ...         RequiresContextResult.from_failure(1),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1319,14 +1319,14 @@ class RequiresContextFutureResult(
           ...     RequiresContextFutureResult.from_ioresult_context(
           ...         RequiresContextIOResult.from_value(1),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOSuccess(1)
 
           >>> assert anyio.run(
           ...     RequiresContextFutureResult.from_ioresult_context(
           ...         RequiresContextIOResult.from_failure(1),
           ...     ),
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -1348,7 +1348,7 @@ class RequiresContextFutureResult(
           >>> from returns.io import IOSuccess
 
           >>> assert anyio.run(RequiresContextFutureResult.from_value(1)(
-          ...    RequiresContextFutureResult.empty,
+          ...    RequiresContextFutureResult.no_args,
           ... ).awaitable) == IOSuccess(1)
 
         """
@@ -1370,7 +1370,7 @@ class RequiresContextFutureResult(
           >>> from returns.io import IOFailure
 
           >>> assert anyio.run(RequiresContextFutureResult.from_failure(1)(
-          ...     RequiresContextFutureResult.empty,
+          ...     RequiresContextFutureResult.no_args,
           ... ).awaitable) == IOFailure(1)
 
         """

--- a/returns/context/requires_context_ioresult.py
+++ b/returns/context/requires_context_ioresult.py
@@ -111,7 +111,7 @@ class RequiresContextIOResult(
     ]
 
     #: A convenient placeholder to call methods created by `.from_value()`.
-    empty: ClassVar[NoDeps] = object()
+    no_args: ClassVar[NoDeps] = object()
 
     def __init__(
         self,
@@ -311,15 +311,15 @@ class RequiresContextIOResult(
 
           >>> assert RequiresContextIOResult.from_value(1).bind_result(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOSuccess(2)
+          ... )(RequiresContextIOResult.no_args) == IOSuccess(2)
 
           >>> assert RequiresContextIOResult.from_value(0).bind_result(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOFailure('<0')
+          ... )(RequiresContextIOResult.no_args) == IOFailure('<0')
 
           >>> assert RequiresContextIOResult.from_failure(':(').bind_result(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOFailure(':(')
+          ... )(RequiresContextIOResult.no_args) == IOFailure(':(')
 
         """
         return RequiresContextIOResult(
@@ -431,11 +431,11 @@ class RequiresContextIOResult(
 
           >>> assert RequiresContextIOResult.from_value(1).bind_io(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOSuccess('1')
+          ... )(RequiresContextIOResult.no_args) == IOSuccess('1')
 
           >>> assert RequiresContextIOResult.from_failure(1).bind_io(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOFailure(1)
+          ... )(RequiresContextIOResult.no_args) == IOFailure(1)
 
         """
         return RequiresContextIOResult(
@@ -459,15 +459,15 @@ class RequiresContextIOResult(
 
           >>> assert RequiresContextIOResult.from_value(1).bind_ioresult(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOSuccess(2)
+          ... )(RequiresContextIOResult.no_args) == IOSuccess(2)
 
           >>> assert RequiresContextIOResult.from_value(0).bind_ioresult(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOFailure('<0')
+          ... )(RequiresContextIOResult.no_args) == IOFailure('<0')
 
           >>> assert RequiresContextIOResult.from_failure(':(').bind_ioresult(
           ...     function,
-          ... )(RequiresContextIOResult.empty) == IOFailure(':(')
+          ... )(RequiresContextIOResult.no_args) == IOFailure(':(')
 
         """
         return RequiresContextIOResult(
@@ -646,7 +646,7 @@ class RequiresContextIOResult(
           >>> from returns.context import RequiresContextIOResult
           >>> from returns.result import Success, Failure
           >>> from returns.io import IOSuccess, IOFailure
-          >>> deps = RequiresContextIOResult.empty
+          >>> deps = RequiresContextIOResult.no_args
 
           >>> assert RequiresContextIOResult.from_result(
           ...    Success(1),
@@ -675,7 +675,7 @@ class RequiresContextIOResult(
           >>> from returns.context import RequiresContextIOResult
 
           >>> assert RequiresContextIOResult.from_io(IO(1))(
-          ...     RequiresContextIOResult.empty,
+          ...     RequiresContextIOResult.no_args,
           ... ) == IOSuccess(1)
 
         """
@@ -697,7 +697,7 @@ class RequiresContextIOResult(
           >>> from returns.context import RequiresContextIOResult
 
           >>> assert RequiresContextIOResult.from_failed_io(IO(1))(
-          ...     RequiresContextIOResult.empty,
+          ...     RequiresContextIOResult.no_args,
           ... ) == IOFailure(1)
 
         """
@@ -716,7 +716,7 @@ class RequiresContextIOResult(
 
           >>> from returns.context import RequiresContextIOResult
           >>> from returns.io import IOSuccess, IOFailure
-          >>> deps = RequiresContextIOResult.empty
+          >>> deps = RequiresContextIOResult.no_args
 
           >>> assert RequiresContextIOResult.from_ioresult(
           ...    IOSuccess(1),
@@ -775,11 +775,11 @@ class RequiresContextIOResult(
 
           >>> assert RequiresContextIOResult.from_typecast(
           ...     RequiresContext.from_value(IOSuccess(1)),
-          ... )(RequiresContextIOResult.empty) == IOSuccess(1)
+          ... )(RequiresContextIOResult.no_args) == IOSuccess(1)
 
           >>> assert RequiresContextIOResult.from_typecast(
           ...     RequiresContext.from_value(IOFailure(1)),
-          ... )(RequiresContextIOResult.empty) == IOFailure(1)
+          ... )(RequiresContextIOResult.no_args) == IOFailure(1)
 
         """
         return RequiresContextIOResult(inner_value)
@@ -867,7 +867,7 @@ class RequiresContextIOResult(
           >>> from returns.io import IOSuccess
 
           >>> assert RequiresContextIOResult.from_value(1)(
-          ...    RequiresContextIOResult.empty,
+          ...    RequiresContextIOResult.no_args,
           ... ) == IOSuccess(1)
 
         """
@@ -887,7 +887,7 @@ class RequiresContextIOResult(
           >>> from returns.io import IOFailure
 
           >>> assert RequiresContextIOResult.from_failure(1)(
-          ...     RequiresContextIOResult.empty,
+          ...     RequiresContextIOResult.no_args,
           ... ) == IOFailure(1)
 
         """

--- a/returns/context/requires_context_result.py
+++ b/returns/context/requires_context_result.py
@@ -100,7 +100,7 @@ class RequiresContextResult(
     ]
 
     #: A convenient placeholder to call methods created by `.from_value()`.
-    empty: ClassVar[NoDeps] = object()
+    no_args: ClassVar[NoDeps] = object()
 
     def __init__(
         self,
@@ -291,15 +291,15 @@ class RequiresContextResult(
 
           >>> assert RequiresContextResult.from_value(1).bind_result(
           ...     function,
-          ... )(RequiresContextResult.empty) == Success(2)
+          ... )(RequiresContextResult.no_args) == Success(2)
 
           >>> assert RequiresContextResult.from_value(0).bind_result(
           ...     function,
-          ... )(RequiresContextResult.empty) == Failure('<0')
+          ... )(RequiresContextResult.no_args) == Failure('<0')
 
           >>> assert RequiresContextResult.from_failure(':(').bind_result(
           ...     function,
-          ... )(RequiresContextResult.empty) == Failure(':(')
+          ... )(RequiresContextResult.no_args) == Failure(':(')
 
         """
         return RequiresContextResult(lambda deps: self(deps).bind(function))
@@ -466,7 +466,7 @@ class RequiresContextResult(
 
           >>> from returns.context import RequiresContextResult
           >>> from returns.result import Success, Failure
-          >>> deps = RequiresContextResult.empty
+          >>> deps = RequiresContextResult.no_args
 
           >>> assert RequiresContextResult.from_result(
           ...    Success(1),
@@ -500,11 +500,11 @@ class RequiresContextResult(
 
           >>> assert RequiresContextResult.from_typecast(
           ...     RequiresContext.from_value(Success(1)),
-          ... )(RequiresContextResult.empty) == Success(1)
+          ... )(RequiresContextResult.no_args) == Success(1)
 
           >>> assert RequiresContextResult.from_typecast(
           ...     RequiresContext.from_value(Failure(1)),
-          ... )(RequiresContextResult.empty) == Failure(1)
+          ... )(RequiresContextResult.no_args) == Failure(1)
 
         """
         return RequiresContextResult(inner_value)

--- a/returns/interfaces/specific/reader.py
+++ b/returns/interfaces/specific/reader.py
@@ -94,8 +94,8 @@ class ReaderLike2(Container2[_FirstType, _SecondType]):
 
     @property
     @abstractmethod
-    def empty(self: _ReaderLike2Type) -> 'NoDeps':
-        """Is required to call ``Reader`` with explicit empty argument."""
+    def no_args(self: _ReaderLike2Type) -> 'NoDeps':
+        """Is required to call ``Reader`` with no explicit arguments."""
 
     @abstractmethod
     def bind_context(
@@ -155,8 +155,8 @@ class ReaderLike3(Container3[_FirstType, _SecondType, _ThirdType]):
 
     @property
     @abstractmethod
-    def empty(self: _ReaderLike3Type) -> 'NoDeps':
-        """Is required to call ``Reader`` with explicit empty argument."""
+    def no_args(self: _ReaderLike3Type) -> 'NoDeps':
+        """Is required to call ``Reader`` with no explicit arguments."""
 
     @abstractmethod
     def bind_context(

--- a/tests/test_context/test_requires_context/test_context_utils.py
+++ b/tests/test_context/test_requires_context/test_context_utils.py
@@ -9,5 +9,5 @@ def test_context_ask():
 
 def test_requires_context_from_value():
     """Ensures that ``from_value`` method works correctly."""
-    assert RequiresContext.from_value(1)(RequiresContext.empty) == 1
+    assert RequiresContext.from_value(1)(RequiresContext.no_args) == 1
     assert RequiresContext.from_value(2)(1) == 2

--- a/tests/test_context/test_requires_context_ioresult/test_requires_context_ioresult_bind.py
+++ b/tests/test_context/test_requires_context_ioresult/test_requires_context_ioresult_bind.py
@@ -32,11 +32,11 @@ def test_bind_regular_result():
     first: RCR[int, str, int] = RCR.from_value(1)
     third: RCR[int, str, int] = RCR.from_failure('a')
 
-    assert first.bind_result(factory)(RCR.empty) == IOSuccess(2)
+    assert first.bind_result(factory)(RCR.no_args) == IOSuccess(2)
     assert RCR.from_value(0).bind_result(
         factory,
-    )(RCR.empty) == IOFailure('nope')
-    assert third.bind_result(factory)(RCR.empty) == IOFailure('a')
+    )(RCR.no_args) == IOFailure('nope')
+    assert third.bind_result(factory)(RCR.no_args) == IOFailure('a')
 
 
 def test_bind_ioresult():
@@ -49,11 +49,11 @@ def test_bind_ioresult():
     first: RCR[int, str, int] = RCR.from_value(1)
     third: RCR[int, str, int] = RCR.from_failure('a')
 
-    assert first.bind_ioresult(factory)(RCR.empty) == IOSuccess(2)
+    assert first.bind_ioresult(factory)(RCR.no_args) == IOSuccess(2)
     assert RCR.from_value(0).bind_ioresult(
         factory,
-    )(RCR.empty) == IOFailure('nope')
-    assert third.bind_ioresult(factory)(RCR.empty) == IOFailure('a')
+    )(RCR.no_args) == IOFailure('nope')
+    assert third.bind_ioresult(factory)(RCR.no_args) == IOFailure('a')
 
 
 def test_bind_regular_context():

--- a/tests/test_context/test_requires_context_result/test_requires_context_result_bind.py
+++ b/tests/test_context/test_requires_context_result/test_requires_context_result_bind.py
@@ -30,11 +30,11 @@ def test_bind_regular_result():
     first: RCR[int, str, int] = RCR.from_value(1)
     third: RCR[int, str, int] = RCR.from_failure('a')
 
-    assert first.bind_result(factory)(RCR.empty) == Success(2)
+    assert first.bind_result(factory)(RCR.no_args) == Success(2)
     assert RCR.from_value(0).bind_result(
         factory,
-    )(RCR.empty) == Failure('nope')
-    assert third.bind_result(factory)(RCR.empty) == Failure('a')
+    )(RCR.no_args) == Failure('nope')
+    assert third.bind_result(factory)(RCR.no_args) == Failure('a')
 
 
 def test_bind_regular_context():

--- a/tests/test_contrib/test_hypothesis/test_type_resolution.py
+++ b/tests/test_contrib/test_hypothesis/test_type_resolution.py
@@ -70,7 +70,7 @@ def test_custom_result_error_types_resolve(thing: CustomResult) -> None:
 @given(
     st.from_type(RequiresContextResultE).filter(
         lambda container: not is_successful(
-            container(RequiresContextResultE.empty),
+            container(RequiresContextResultE.no_args),
         ),
     ),
 )
@@ -78,7 +78,7 @@ def test_reader_result_error_alias_resolves(
     thing: RequiresContextResultE,
 ) -> None:
     """Ensures that type aliases are resolved correctly."""
-    real_result = thing(RequiresContextResultE.empty)
+    real_result = thing(RequiresContextResultE.no_args)
     assert isinstance(real_result.failure(), Exception)
 
 
@@ -90,7 +90,7 @@ def test_custom_readerresult_types_resolve(
     thing: CustomReaderResult,
 ) -> None:
     """Ensures that type aliases are resolved correctly."""
-    real_result = thing(RequiresContextResultE.empty)
+    real_result = thing(RequiresContextResultE.no_args)
     if is_successful(real_result):
         assert isinstance(real_result.unwrap(), int)
     else:

--- a/tests/test_pipeline/test_managed/test_managed_reader_future_result.py
+++ b/tests/test_pipeline/test_managed/test_managed_reader_future_result.py
@@ -119,7 +119,7 @@ async def test_all_success(acquire, use, release, final_result, log):
         release(pipeline_logs),
     )(acquire())
 
-    assert await pipeline_result(ReaderFutureResult.empty) == final_result
+    assert await pipeline_result(ReaderFutureResult.no_args) == final_result
     assert pipeline_logs == log
 
 
@@ -131,7 +131,7 @@ async def test_full_typing():
         _use_success,
         _ReleaseSuccess(logs),
     )(_acquire_success())
-    inner = pipeline_result(ReaderFutureResult.empty)
+    inner = pipeline_result(ReaderFutureResult.no_args)
 
     assert await inner == IOSuccess('use success')
     assert logs == [('acquire success', Success('use success'))]

--- a/tests/test_pipeline/test_managed/test_managed_reader_ioresult.py
+++ b/tests/test_pipeline/test_managed/test_managed_reader_ioresult.py
@@ -113,7 +113,7 @@ def test_all_success(acquire, use, release, final_result, log):
         release(pipeline_logs),
     )(acquire)
 
-    assert pipeline_result(ReaderIOResult.empty) == final_result
+    assert pipeline_result(ReaderIOResult.no_args) == final_result
     assert pipeline_logs == log
 
 
@@ -125,5 +125,5 @@ def test_full_typing():
         _ReleaseSuccess(logs),
     )(_acquire_success)
 
-    assert pipeline_result(ReaderIOResult.empty) == IOSuccess('use success')
+    assert pipeline_result(ReaderIOResult.no_args) == IOSuccess('use success')
     assert logs == [('acquire success', Success('use success'))]

--- a/typesafety/test_interfaces/test_specific/test_reader/test_reader_based2.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader/test_reader_based2.yml
@@ -15,7 +15,7 @@
         SupportsKind2['MyClass', _ReturnType, _EnvType],
         ReaderBased2[_ReturnType, _EnvType],
     ):
-        empty: ClassVar[NoDeps] = object()
+        no_args: ClassVar[NoDeps] = object()
 
         def __call__(self, deps: _EnvType) -> _ReturnType:
             ...
@@ -70,7 +70,7 @@
     ):
         ...
   out: |
-    main:10: error: Final class main.MyClass has abstract attributes "__call__", "apply", "ask", "bind", "bind_context", "empty", "from_context", "from_value", "map", "modify_env"
+    main:10: error: Final class main.MyClass has abstract attributes "__call__", "apply", "ask", "bind", "bind_context", "from_context", "from_value", "map", "modify_env", "no_args"
 
 
 - case: reader_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader/test_reader_like2.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader/test_reader_like2.yml
@@ -15,7 +15,7 @@
         SupportsKind2['MyClass', _ReturnType, _EnvType],
         ReaderLike2[_ReturnType, _EnvType],
     ):
-        empty: ClassVar[NoDeps] = object()
+        no_args: ClassVar[NoDeps] = object()
 
         def bind_context(
             self,
@@ -67,7 +67,7 @@
     ):
         ...
   out: |
-    main:10: error: Final class main.MyClass has abstract attributes "apply", "ask", "bind", "bind_context", "empty", "from_context", "from_value", "map", "modify_env"
+    main:10: error: Final class main.MyClass has abstract attributes "apply", "ask", "bind", "bind_context", "from_context", "from_value", "map", "modify_env", "no_args"
 
 
 - case: reader_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader/test_reader_like3.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader/test_reader_like3.yml
@@ -16,7 +16,7 @@
         SupportsKind3['MyClass', _ValueType, _ErrorType, _EnvType],
         ReaderLike3[_ValueType, _ErrorType, _EnvType],
     ):
-        empty: ClassVar[NoDeps] = object()
+        no_args: ClassVar[NoDeps] = object()
 
         def __call__(self, deps: _EnvType) -> Union[_ValueType, _ErrorType]:
             ...
@@ -72,7 +72,7 @@
     ):
         ...
   out: |
-    main:11: error: Final class main.MyClass has abstract attributes "apply", "ask", "bind", "bind_context", "empty", "from_context", "from_value", "map", "modify_env"
+    main:11: error: Final class main.MyClass has abstract attributes "apply", "ask", "bind", "bind_context", "from_context", "from_value", "map", "modify_env", "no_args"
 
 
 - case: reader_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader_future_result/test_reader_future_result_based.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader_future_result/test_reader_future_result_based.yml
@@ -41,7 +41,7 @@
     ):
         ...
   out: |
-    main:13: error: Final class main.MyClass has abstract attributes "__call__", "alt", "apply", "ask", "bind", "bind_async", "bind_async_context_future_result", "bind_async_future", "bind_async_future_result", "bind_awaitable", "bind_context", "bind_context_future_result", "bind_context_ioresult", "bind_context_result", "bind_future", "bind_future_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "empty", "from_context", "from_failed_context", "from_failed_future", "from_failed_io", "from_failure", "from_future", "from_future_result_context", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "rescue", "swap"
+    main:13: error: Final class main.MyClass has abstract attributes "__call__", "alt", "apply", "ask", "bind", "bind_async", "bind_async_context_future_result", "bind_async_future", "bind_async_future_result", "bind_awaitable", "bind_context", "bind_context_future_result", "bind_context_ioresult", "bind_context_result", "bind_future", "bind_future_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "from_context", "from_failed_context", "from_failed_future", "from_failed_io", "from_failure", "from_future", "from_future_result_context", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "no_args", "rescue", "swap"
 
 
 - case: reader_future_result_based_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader_future_result/test_reader_future_result_like.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader_future_result/test_reader_future_result_like.yml
@@ -62,7 +62,7 @@
     ):
         ...
   out: |
-    main:13: error: Final class main.MyClass has abstract attributes "alt", "apply", "ask", "bind", "bind_async", "bind_async_context_future_result", "bind_async_future", "bind_async_future_result", "bind_awaitable", "bind_context", "bind_context_future_result", "bind_context_ioresult", "bind_context_result", "bind_future", "bind_future_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "empty", "from_context", "from_failed_context", "from_failed_future", "from_failed_io", "from_failure", "from_future", "from_future_result_context", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "rescue", "swap"
+    main:13: error: Final class main.MyClass has abstract attributes "alt", "apply", "ask", "bind", "bind_async", "bind_async_context_future_result", "bind_async_future", "bind_async_future_result", "bind_awaitable", "bind_context", "bind_context_future_result", "bind_context_ioresult", "bind_context_result", "bind_future", "bind_future_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "from_context", "from_failed_context", "from_failed_future", "from_failed_io", "from_failure", "from_future", "from_future_result_context", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "no_args", "rescue", "swap"
 
 
 - case: reader_future_result_like_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader_ioresult/test_reader_ioresult_based.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader_ioresult/test_reader_ioresult_based.yml
@@ -37,7 +37,7 @@
     ):
         ...
   out: |
-    main:11: error: Final class main.MyClass has abstract attributes "__call__", "alt", "apply", "ask", "bind", "bind_context", "bind_context_ioresult", "bind_context_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "empty", "from_context", "from_failed_context", "from_failed_io", "from_failure", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "rescue", "swap"
+    main:11: error: Final class main.MyClass has abstract attributes "__call__", "alt", "apply", "ask", "bind", "bind_context", "bind_context_ioresult", "bind_context_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "from_context", "from_failed_context", "from_failed_io", "from_failure", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "no_args", "rescue", "swap"
 
 
 - case: reader_ioresult_based_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader_ioresult/test_reader_ioresult_like.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader_ioresult/test_reader_ioresult_like.yml
@@ -52,7 +52,7 @@
     ):
         ...
   out: |
-    main:11: error: Final class main.MyClass has abstract attributes "alt", "apply", "ask", "bind", "bind_context", "bind_context_ioresult", "bind_context_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "empty", "from_context", "from_failed_context", "from_failed_io", "from_failure", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "rescue", "swap"
+    main:11: error: Final class main.MyClass has abstract attributes "alt", "apply", "ask", "bind", "bind_context", "bind_context_ioresult", "bind_context_result", "bind_io", "bind_ioresult", "bind_result", "compose_result", "from_context", "from_failed_context", "from_failed_io", "from_failure", "from_io", "from_ioresult", "from_ioresult_context", "from_result", "from_result_context", "from_value", "map", "modify_env", "no_args", "rescue", "swap"
 
 
 - case: reader_ioresult_like_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader_result/test_reader_result_based.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader_result/test_reader_result_based.yml
@@ -37,7 +37,7 @@
     ):
         ...
   out: |
-    main:11: error: Final class main.MyClass has abstract attributes "__call__", "alt", "apply", "ask", "bind", "bind_context", "bind_context_result", "bind_result", "empty", "from_context", "from_failed_context", "from_failure", "from_result", "from_result_context", "from_value", "map", "modify_env", "rescue", "swap"
+    main:11: error: Final class main.MyClass has abstract attributes "__call__", "alt", "apply", "ask", "bind", "bind_context", "bind_context_result", "bind_result", "from_context", "from_failed_context", "from_failure", "from_result", "from_result_context", "from_value", "map", "modify_env", "no_args", "rescue", "swap"
 
 
 - case: reader_result_based_inheritance_wrong

--- a/typesafety/test_interfaces/test_specific/test_reader_result/test_reader_result_like.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader_result/test_reader_result_like.yml
@@ -59,7 +59,7 @@
     ):
         ...
   out: |
-    main:11: error: Final class main.MyClass has abstract attributes "alt", "apply", "ask", "bind", "bind_context", "bind_context_result", "bind_result", "empty", "from_context", "from_failed_context", "from_failure", "from_result", "from_result_context", "from_value", "map", "modify_env", "rescue", "swap"
+    main:11: error: Final class main.MyClass has abstract attributes "alt", "apply", "ask", "bind", "bind_context", "bind_context_result", "bind_result", "from_context", "from_failed_context", "from_failure", "from_result", "from_result_context", "from_value", "map", "modify_env", "no_args", "rescue", "swap"
 
 
 - case: reader_result_like_inheritance_wrong


### PR DESCRIPTION
# Renames property `empty` to `no_args` of `ReaderLike2` and `ReaderLike3` interfaces 

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #640 