### PR TITLE
Sets documentation theme color attribute

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,6 +165,7 @@ html_theme_options = {
     ),
     'github_user': 'dry-python',
     'github_repo': 'returns',
+    'color': '#E8371A',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/pages/interfaces.rst
+++ b/docs/pages/interfaces.rst
@@ -239,21 +239,6 @@ us to create our custom bindable.
   >>> bag_of_peanuts: Bag[Peanuts] = Bag(Peanuts(10))
   >>> assert bag_of_peanuts.bind(get_half) == Bag(Peanuts(5))
 
-
-Applicative
------------
-
-.. currentmodule:: returns.interfaces.applicative
-
-Laws
-~~~~
-
-
-Container
----------
-
-.. currentmodule:: returns.interfaces.container
-
 Laws
 ~~~~
 
@@ -299,6 +284,21 @@ respect three new laws.
   >>> assert bag.bind(minus_one).bind(half) == bag.bind(
   ...    lambda value: minus_one(value).bind(half),
   ... )
+
+
+Applicative
+-----------
+
+.. currentmodule:: returns.interfaces.applicative
+
+Laws
+~~~~
+
+
+Container
+---------
+
+.. currentmodule:: returns.interfaces.container
 
 
 More!


### PR DESCRIPTION
# Sets documentation theme color attribute

After some research I found where we need to modify!!
It's just a property called `color` we have to add in our `conf.py`.
[Reference](https://sphinx-typlog-theme.readthedocs.io/en/latest/options.html#color)

It's working:
![image](https://user-images.githubusercontent.com/25423500/95647397-7f816480-0aa5-11eb-94e4-506ca009acb6.png)

I've used `#E8371A`, it's the same from `sphinx-typlog-theme`. This color is used to:
* Keyword highlight
* Link hover
* Mouse selection

You can try it online [here](https://returns--669.org.readthedocs.build/en/669/)

Btw, the Bindable's Laws was in a wrong position!!

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)

## Related issues

Closes #649 