### PR TITLE
Bumps sphinx from 3.5.4 to 4.0.2 in /docs & Fix build docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,16 @@ import sphinx
 
 sys.path.insert(0, os.path.abspath('..'))
 
+# TODO: Removes the whole if statement when the below PR is merged:
+# https://github.com/mgaitan/sphinxcontrib-mermaid/pull/71
+# From `sphinx>=4` the `ENOENT` constant was fully deprecated,
+# in order to make the things work with `sphinxcontrib-mermaid`
+# we need to mokey patch that constant.
+if sphinx.version_info[0] >= 4:
+    import errno
+    import sphinx.util.osutil  # noqa: I003, WPS301
+    sphinx.util.osutil.ENOENT = errno.ENOENT
+
 
 # -- Monkeypatches -----------------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # This file is used to setup env
 # to generate documentation.
 
-sphinx==3.5.4
+sphinx==4.0.2
 sphinx_autodoc_typehints==1.12.0
 sphinxcontrib-mermaid==0.6.3
 sphinx-typlog-theme==0.8.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,3 +16,7 @@ typing-extensions==3.10.0.0
 mypy==0.812
 pytest==6.2.4
 hypothesis==6.12.0
+
+# TODO: Remove this lock when we found and fix the route case.
+# See: https://github.com/typlog/sphinx-typlog-theme/issues/22
+jinja2==2.11.2


### PR DESCRIPTION
I've bumped the `sphinx` in our docs requirements to version `4.0.2` AND to make `sphinxcontrib-mermaid` I've added an temporary fix!

And also I need to lock the `Jinja` version, it was the root of the problem on read the docs!