### PR TITLE
Bumps `mypy` from `0.812` to `0.902`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -771,7 +771,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "mypy"
-version = "0.812"
+version = "0.902"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -779,11 +779,13 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
-typed-ast = ">=1.4.0,<1.5.0"
+toml = "*"
+typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.7.4"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -1516,7 +1518,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4ed2fc4c91ec049a8fb620e3a00752adf02d6e3c1f81988b70478ec5b2642c9e"
+content-hash = "75db15fe4f6011f79613502bcab0163afed2128a61561428e120dc00fcb2ba20"
 
 [metadata.files]
 alabaster = [
@@ -1585,36 +1587,24 @@ cffi = [
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
-    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f"},
-    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed"},
-    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55"},
     {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
     {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
     {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
-    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69"},
-    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05"},
-    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc"},
     {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
     {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
     {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
-    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373"},
-    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f"},
-    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76"},
     {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
     {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
     {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
-    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0"},
-    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333"},
-    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7"},
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
@@ -1874,39 +1864,20 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 marshmallow = [
@@ -1930,28 +1901,29 @@ more-itertools = [
     {file = "more_itertools-8.7.0-py3-none-any.whl", hash = "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced"},
 ]
 mypy = [
-    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
-    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
-    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
-    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
-    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
-    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
-    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
-    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
-    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
-    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
-    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
-    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
-    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
-    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
-    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
-    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
-    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
-    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
-    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
-    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
-    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
-    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
+    {file = "mypy-0.902-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3f12705eabdd274b98f676e3e5a89f247ea86dc1af48a2d5a2b080abac4e1243"},
+    {file = "mypy-0.902-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:2f9fedc1f186697fda191e634ac1d02f03d4c260212ccb018fabbb6d4b03eee8"},
+    {file = "mypy-0.902-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:0756529da2dd4d53d26096b7969ce0a47997123261a5432b48cc6848a2cb0bd4"},
+    {file = "mypy-0.902-cp35-cp35m-win_amd64.whl", hash = "sha256:68a098c104ae2b75e946b107ef69dd8398d54cb52ad57580dfb9fc78f7f997f0"},
+    {file = "mypy-0.902-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cd01c599cf9f897b6b6c6b5d8b182557fb7d99326bcdf5d449a0fbbb4ccee4b9"},
+    {file = "mypy-0.902-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:e89880168c67cf4fde4506b80ee42f1537ad66ad366c101d388b3fd7d7ce2afd"},
+    {file = "mypy-0.902-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ebe2bc9cb638475f5d39068d2dbe8ae1d605bb8d8d3ff281c695df1670ab3987"},
+    {file = "mypy-0.902-cp36-cp36m-win_amd64.whl", hash = "sha256:f89bfda7f0f66b789792ab64ce0978e4a991a0e4dd6197349d0767b0f1095b21"},
+    {file = "mypy-0.902-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:746e0b0101b8efec34902810047f26a8c80e1efbb4fc554956d848c05ef85d76"},
+    {file = "mypy-0.902-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0190fb77e93ce971954c9e54ea61de2802065174e5e990c9d4c1d0f54fbeeca2"},
+    {file = "mypy-0.902-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:b5dfcd22c6bab08dfeded8d5b44bdcb68c6f1ab261861e35c470b89074f78a70"},
+    {file = "mypy-0.902-cp37-cp37m-win_amd64.whl", hash = "sha256:b5ba1f0d5f9087e03bf5958c28d421a03a4c1ad260bf81556195dffeccd979c4"},
+    {file = "mypy-0.902-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9ef5355eaaf7a23ab157c21a44c614365238a7bdb3552ec3b80c393697d974e1"},
+    {file = "mypy-0.902-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:517e7528d1be7e187a5db7f0a3e479747307c1b897d9706b1c662014faba3116"},
+    {file = "mypy-0.902-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:fd634bc17b1e2d6ce716f0e43446d0d61cdadb1efcad5c56ca211c22b246ebc8"},
+    {file = "mypy-0.902-cp38-cp38-win_amd64.whl", hash = "sha256:fc4d63da57ef0e8cd4ab45131f3fe5c286ce7dd7f032650d0fbc239c6190e167"},
+    {file = "mypy-0.902-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:353aac2ce41ddeaf7599f1c73fed2b75750bef3b44b6ad12985a991bc002a0da"},
+    {file = "mypy-0.902-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ae94c31bb556ddb2310e4f913b706696ccbd43c62d3331cd3511caef466871d2"},
+    {file = "mypy-0.902-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:8be7bbd091886bde9fcafed8dd089a766fa76eb223135fe5c9e9798f78023a20"},
+    {file = "mypy-0.902-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:4efc67b9b3e2fddbe395700f91d5b8deb5980bfaaccb77b306310bd0b9e002eb"},
+    {file = "mypy-0.902-cp39-cp39-win_amd64.whl", hash = "sha256:9f1d74eeb3f58c7bd3f3f92b8f63cb1678466a55e2c4612bf36909105d0724ab"},
+    {file = "mypy-0.902-py3-none-any.whl", hash = "sha256:a26d0e53e90815c765f91966442775cf03b8a7514a4e960de7b5320208b07269"},
+    {file = "mypy-0.902.tar.gz", hash = "sha256:9236c21194fde5df1b4d8ebc2ef2c1f2a5dc7f18bcbea54274937cae2e20a01c"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -2078,26 +2050,18 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -2125,29 +2089,20 @@ rfc3986 = [
     {file = "ruamel.yaml.clib-0.2.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:73b3d43e04cc4b228fa6fa5d796409ece6fcb53a6c270eb2048109cbcbc3b9c2"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:53b9dd1abd70e257a6e32f934ebc482dac5edb8c93e23deb663eac724c30b026"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:839dd72545ef7ba78fd2aa1a5dd07b33696adf3e68fae7f31327161c1093001b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1236df55e0f73cd138c0eca074ee086136c3f16a97c2ac719032c050f7e0622f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win32.whl", hash = "sha256:b1e981fe1aff1fd11627f531524826a4dcc1f26c726235a52fcb62ded27d150f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e52c96ca66de04be42ea2278012a2342d89f5e82b4512fb6fb7134e377e2e62"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a873e4d4954f865dcb60bdc4914af7eaae48fb56b60ed6daa1d6251c72f5337c"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ab845f1f51f7eb750a78937be9f79baea4a42c7960f5a94dde34e69f3cce1988"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2fd336a5c6415c82e2deb40d08c222087febe0aebe520f4d21910629018ab0f3"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win32.whl", hash = "sha256:e9f7d1d8c26a6a12c23421061f9022bb62704e38211fe375c645485f38df34a2"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:2602e91bd5c1b874d6f93d3086f9830f3e907c543c7672cf293a97c3fabdcd91"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:44c7b0498c39f27795224438f1a6be6c5352f82cb887bc33d962c3a3acc00df6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e8fd0a22c9d92af3a34f91e8a2594eeb35cba90ab643c5e0e643567dc8be43e"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:75f0ee6839532e52a3a53f80ce64925ed4aed697dd3fa890c4c918f3304bd4f4"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:464e66a04e740d754170be5e740657a3b3b6d2bcc567f0c3437879a6e6087ff6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:52ae5739e4b5d6317b52f5b040b1b6639e8af68a5b8fd606a8b08658fbd0cab5"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4df5019e7783d14b79217ad9c56edf1ba7485d614ad5a385d1b3c768635c81c0"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5254af7d8bdf4d5484c089f929cb7f5bafa59b4f01d4f48adda4be41e6d29f99"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8be05be57dc5c7b4a0b24edcaa2f7275866d9c907725226cdde46da09367d923"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win32.whl", hash = "sha256:74161d827407f4db9072011adcfb825b5258a5ccb3d2cd518dd6c9edea9e30f1"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:058a1cc3df2a8aecc12f983a48bda99315cebf55a3b3a5463e37bb599b05727b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c6ac7e45367b1317e56f1461719c853fd6825226f45b835df7436bb04031fd8a"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b4b0d31f2052b3f9f9b5327024dc629a253a83d8649d4734ca7f35b60ec3e9e5"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1f8c0a4577c0e6c99d208de5c4d3fd8aceed9574bb154d7a2b21c16bb924154c"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win32.whl", hash = "sha256:46d6d20815064e8bb023ea8628cfb7402c0f0e83de2c2227a88097e239a7dffd"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:6c0a5dc52fc74eb87c67374a4e554d4761fd42a4d01390b7e868b30d21f4b8bb"},
     {file = "ruamel.yaml.clib-0.2.2.tar.gz", hash = "sha256:2d24bd98af676f4990c4d715bcdc2a60b19c56a3fb3a763164d2d8ca0e806ba7"},
 ]
 safety = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ trio = "^0.19"
 attrs = "^21.2"
 httpx = "^0.18"
 
-mypy = "^0.812"
+mypy = "^0.902"
 wemake-python-styleguide = "^0.15"
 flake8-pytest-style = "^1.4"
 flake8-pyi = "^20.10"

--- a/typesafety/test_context/test_requires_context/test_context.yml
+++ b/typesafety/test_context/test_requires_context/test_context.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.context import RequiresContext
 
-    reveal_type(RequiresContext.ask())  # N: Revealed type is 'returns.context.requires_context.RequiresContext[<nothing>, <nothing>]'
+    reveal_type(RequiresContext.ask())  # N: Revealed type is "returns.context.requires_context.RequiresContext[<nothing>, <nothing>]"
 
 
 - case: context_ask2
@@ -11,7 +11,7 @@
   main: |
     from returns.context import RequiresContext
 
-    reveal_type(RequiresContext[int, str].ask())  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.str*, builtins.str*]'
+    reveal_type(RequiresContext[int, str].ask())  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.str*, builtins.str*]"
 
 
 - case: requires_context_from_value
@@ -19,7 +19,7 @@
   main: |
     from returns.context import RequiresContext
 
-    reveal_type(RequiresContext.from_value(1))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int*, Any]'
+    reveal_type(RequiresContext.from_value(1))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int*, Any]"
 
 
 - case: requires_context_from_context
@@ -28,4 +28,4 @@
     from returns.context import RequiresContext
 
     x: RequiresContext[int, str]
-    reveal_type(RequiresContext.from_context(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int*, builtins.str*]'
+    reveal_type(RequiresContext.from_context(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int*, builtins.str*]"

--- a/typesafety/test_context/test_requires_context/test_requires_context_cast.yml
+++ b/typesafety/test_context/test_requires_context/test_requires_context_cast.yml
@@ -6,7 +6,7 @@
     first: RequiresContext[TypeError, int]  # we can only cast return type
     second: RequiresContext[Exception, int] = first
 
-    reveal_type(second)  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.Exception, builtins.int]'
+    reveal_type(second)  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.Exception, builtins.int]"
 
 
 - case: context_wrong_cast
@@ -47,6 +47,6 @@
     reveal_type(func().bind(third))
   out: |
     main:21: error: Argument 1 to "bind" of "RequiresContext" has incompatible type "Callable[[int], RequiresContext[int, A]]"; expected "Callable[[int], KindN[RequiresContext[Any, Any], int, B, Any]]"
-    main:21: note: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int*, main.B]'
+    main:21: note: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int*, main.B]"
     main:22: error: Argument 1 to "bind" of "RequiresContext" has incompatible type "Callable[[int], RequiresContext[int, C]]"; expected "Callable[[int], KindN[RequiresContext[Any, Any], int, B, Any]]"
-    main:22: note: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int*, main.B]'
+    main:22: note: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int*, main.B]"

--- a/typesafety/test_context/test_requires_context/test_requires_context_type.yml
+++ b/typesafety/test_context/test_requires_context/test_requires_context_type.yml
@@ -5,7 +5,7 @@
 
     first: RequiresContext[str, int]
 
-    reveal_type(first(1))  # N: Revealed type is 'builtins.str*'
+    reveal_type(first(1))  # N: Revealed type is "builtins.str*"
 
 
 - case: requires_context_getattr
@@ -24,7 +24,7 @@
 
     first: RequiresContext[str, int]
 
-    reveal_type(first.map(lambda char: float(char)))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]'
+    reveal_type(first.map(lambda char: float(char)))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]"
 
 
 - case: requires_context_apply_correct
@@ -36,7 +36,7 @@
     first: RequiresContext[str, int]
     second: RequiresContext[Callable[[str], float], int]
 
-    reveal_type(first.apply(second))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]'
+    reveal_type(first.apply(second))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]"
 
 
 - case: requires_context_bind_correct
@@ -49,7 +49,7 @@
     def function(arg: str) -> RequiresContext[float, int]:
         return RequiresContext.from_value(1.5)
 
-    reveal_type(first.bind(function))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]'
+    reveal_type(first.bind(function))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]"
 
 
 - case: requires_context_bind_context_correct
@@ -62,7 +62,7 @@
     def function(arg: str) -> RequiresContext[float, int]:
         return RequiresContext.from_value(1.5)
 
-    reveal_type(first.bind_context(function))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]'
+    reveal_type(first.bind_context(function))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.float*, builtins.int]"
 
 
 - case: requires_context_modify_env
@@ -71,7 +71,7 @@
     from returns.context import RequiresContext
 
     first: RequiresContext[float, int]
-    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is 'builtins.float*'
+    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is "builtins.float*"
 
 
 - case: requires_context_call_wrong

--- a/typesafety/test_context/test_requires_context/test_requires_context_typecast.yml
+++ b/typesafety/test_context/test_requires_context/test_requires_context_typecast.yml
@@ -6,7 +6,7 @@
 
     x: RequiresContextIOResult[int, float, str]
 
-    reveal_type(RequiresContext.from_requires_context_ioresult(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[returns.io.IOResult[builtins.int*, builtins.float*], builtins.str*]'
+    reveal_type(RequiresContext.from_requires_context_ioresult(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[returns.io.IOResult[builtins.int*, builtins.float*], builtins.str*]"
 
 
 - case: requires_context_from_requires_context_result
@@ -17,7 +17,7 @@
 
     x: RequiresContextResult[int, float, str]
 
-    reveal_type(RequiresContext.from_requires_context_result(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[returns.result.Result[builtins.int*, builtins.float*], builtins.str*]'
+    reveal_type(RequiresContext.from_requires_context_result(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[returns.result.Result[builtins.int*, builtins.float*], builtins.str*]"
 
 
 - case: requires_context_from_requires_context_future_result
@@ -28,4 +28,4 @@
 
     x: RequiresContextFutureResult[int, float, str]
 
-    reveal_type(RequiresContext.from_requires_context_future_result(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[returns.future.FutureResult[builtins.int*, builtins.float*], builtins.str*]'
+    reveal_type(RequiresContext.from_requires_context_future_result(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[returns.future.FutureResult[builtins.int*, builtins.float*], builtins.str*]"

--- a/typesafety/test_context/test_requires_context_future_result/test_context_future_result.yml
+++ b/typesafety/test_context/test_requires_context_future_result/test_context_future_result.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.context import RequiresContextFutureResult
 
-    reveal_type(RequiresContextFutureResult.ask())  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[<nothing>, <nothing>, <nothing>]'
+    reveal_type(RequiresContextFutureResult.ask())  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[<nothing>, <nothing>, <nothing>]"
 
 
 - case: context_result_future_ask2
@@ -11,4 +11,4 @@
   main: |
     from returns.context import RequiresContextFutureResult
 
-    reveal_type(RequiresContextFutureResult[int, bool, str].ask())  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str*, builtins.bool*, builtins.str*]'
+    reveal_type(RequiresContextFutureResult[int, bool, str].ask())  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str*, builtins.bool*, builtins.str*]"

--- a/typesafety/test_context/test_requires_context_future_result/test_requires_context_future_result.yml
+++ b/typesafety/test_context/test_requires_context_future_result/test_requires_context_future_result.yml
@@ -5,7 +5,7 @@
 
     x: RequiresContextFutureResult[int, float, str]
 
-    reveal_type(x('a'))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, builtins.float*]'
+    reveal_type(x('a'))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, builtins.float*]"
 
 
 - case: requires_context_future_result_getattr
@@ -24,7 +24,7 @@
 
     x: RequiresContextFutureResult[int, float, str]
 
-    reveal_type(x.swap())  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float*, builtins.int*, builtins.str*]'
+    reveal_type(x.swap())  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float*, builtins.int*, builtins.str*]"
 
 
 - case: requires_context_future_result_map
@@ -34,7 +34,7 @@
 
     x: RequiresContextFutureResult[int, float, str]
 
-    reveal_type(x.map(bool))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.map(bool))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_apply
@@ -46,7 +46,7 @@
     x: RequiresContextFutureResult[int, float, str]
     y: RequiresContextFutureResult[Callable[[int], bool], float, str]
 
-    reveal_type(x.apply(y))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.apply(y))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind
@@ -59,7 +59,7 @@
     def test(param: int) -> RequiresContextFutureResult[bool, float, str]:
         ...
 
-    reveal_type(x.bind(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_awaitable
@@ -72,7 +72,7 @@
 
     first: RequiresContextFutureResult[int, str, bool]
 
-    reveal_type(first.bind_awaitable(bind_awaitable))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float*, builtins.str, builtins.bool]'
+    reveal_type(first.bind_awaitable(bind_awaitable))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float*, builtins.str, builtins.bool]"
 
 
 - case: requires_context_future_result_bind_async
@@ -85,7 +85,7 @@
 
     first: RequiresContextFutureResult[int, str, bool]
 
-    reveal_type(first.bind_async(bind_async))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float*, builtins.str, builtins.bool]'
+    reveal_type(first.bind_async(bind_async))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float*, builtins.str, builtins.bool]"
 
 
 - case: requires_context_future_result_bind_result
@@ -99,7 +99,7 @@
     def test(param: int) -> Result[bool, float]:
         ...
 
-    reveal_type(x.bind_result(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_result(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_ioresult
@@ -113,7 +113,7 @@
     def test(param: int) -> IOResult[bool, float]:
         ...
 
-    reveal_type(x.bind_ioresult(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_ioresult(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_io
@@ -127,7 +127,7 @@
     def test(param: int) -> IO[bool]:
         ...
 
-    reveal_type(x.bind_io(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_io(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_future
@@ -141,7 +141,7 @@
     def test(param: int) -> Future[bool]:
         ...
 
-    reveal_type(x.bind_future(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_future(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_future_result
@@ -155,7 +155,7 @@
     def test(param: int) -> FutureResult[bool, float]:
         ...
 
-    reveal_type(x.bind_future_result(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_future_result(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_async_future
@@ -169,7 +169,7 @@
     async def test(param: int) -> Future[bool]:
         ...
 
-    reveal_type(x.bind_async_future(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_async_future(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_async_future_result
@@ -183,7 +183,7 @@
     async def test(param: int) -> FutureResult[bool, float]:
         ...
 
-    reveal_type(x.bind_async_future_result(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_async_future_result(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_context
@@ -196,7 +196,7 @@
     def test(param: int) -> RequiresContext[bool, str]:
         ...
 
-    reveal_type(x.bind_context(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_context(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_context_result
@@ -209,7 +209,7 @@
     def test(param: int) -> RequiresContextResult[bool, float, str]:
         ...
 
-    reveal_type(x.bind_context_result(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_context_result(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_bind_context_ioresult
@@ -222,7 +222,7 @@
     def test(param: int) -> RequiresContextIOResult[bool, float, str]:
         ...
 
-    reveal_type(x.bind_context_ioresult(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_context_ioresult(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_future_result_lash
@@ -235,7 +235,7 @@
     def test(param: float) -> RequiresContextFutureResult[int, bool, str]:
         ...
 
-    reveal_type(x.lash(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool*, builtins.str]'
+    reveal_type(x.lash(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool*, builtins.str]"
 
 
 - case: requires_context_future_result_alt
@@ -248,7 +248,7 @@
     def test(param: float) -> bool:
         ...
 
-    reveal_type(x.alt(test))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool*, builtins.str]'
+    reveal_type(x.alt(test))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool*, builtins.str]"
 
 
 - case: requires_context_future_result_modify_env
@@ -257,4 +257,4 @@
     from returns.context import RequiresContextFutureResult
 
     first: RequiresContextFutureResult[float, bool, int]
-    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.bool*]'
+    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.bool*]"

--- a/typesafety/test_context/test_requires_context_future_result/test_requires_context_future_result_cast.yml
+++ b/typesafety/test_context/test_requires_context_future_result/test_requires_context_future_result_cast.yml
@@ -4,7 +4,7 @@
     from returns.context import RequiresContextFutureResult
 
     first: RequiresContextFutureResult[object, Exception, str] = RequiresContextFutureResult.from_value(1)
-    reveal_type(first)  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(first)  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_future_result_failure_cast
@@ -13,7 +13,7 @@
     from returns.context import RequiresContextFutureResult
 
     first: RequiresContextFutureResult[object, Exception, str] = RequiresContextFutureResult.from_failure(TypeError())
-    reveal_type(first)  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(first)  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_future_result_env_cast
@@ -24,7 +24,7 @@
     first: RequiresContextFutureResult[object, Exception, object]
     second: RequiresContextFutureResult[object, Exception, str] = first
 
-    reveal_type(second)  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(second)  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_future_result_wrong_cast

--- a/typesafety/test_context/test_requires_context_future_result/test_requires_context_future_result_unit.yml
+++ b/typesafety/test_context/test_requires_context_future_result/test_requires_context_future_result_unit.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.context import RequiresContextFutureResult
 
-    reveal_type(RequiresContextFutureResult.from_value(1))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, Any, Any]'
+    reveal_type(RequiresContextFutureResult.from_value(1))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, Any, Any]"
 
 
 - case: requires_context_future_result_failure
@@ -11,7 +11,7 @@
   main: |
     from returns.context import RequiresContextFutureResult
 
-    reveal_type(RequiresContextFutureResult.from_failure(1))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.int*, Any]'
+    reveal_type(RequiresContextFutureResult.from_failure(1))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.int*, Any]"
 
 
 - case: requires_context_future_result_result
@@ -22,7 +22,7 @@
 
     r: Result[int, str]
 
-    reveal_type(RequiresContextFutureResult.from_result(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, Any]'
+    reveal_type(RequiresContextFutureResult.from_result(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, Any]"
 
 
 - case: requires_context_future_result_io
@@ -33,7 +33,7 @@
 
     r: IO[int]
 
-    reveal_type(RequiresContextFutureResult.from_io(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, Any, Any]'
+    reveal_type(RequiresContextFutureResult.from_io(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, Any, Any]"
 
 
 - case: requires_context_future_result_failed_io
@@ -44,7 +44,7 @@
 
     r: IO[int]
 
-    reveal_type(RequiresContextFutureResult.from_failed_io(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.int*, Any]'
+    reveal_type(RequiresContextFutureResult.from_failed_io(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.int*, Any]"
 
 
 - case: requires_context_future_result_ioresult
@@ -55,7 +55,7 @@
 
     r: IOResult[int, str]
 
-    reveal_type(RequiresContextFutureResult.from_ioresult(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, Any]'
+    reveal_type(RequiresContextFutureResult.from_ioresult(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, Any]"
 
 
 - case: requires_context_future_result_future
@@ -66,7 +66,7 @@
 
     r: Future[int]
 
-    reveal_type(RequiresContextFutureResult.from_future(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, Any, Any]'
+    reveal_type(RequiresContextFutureResult.from_future(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, Any, Any]"
 
 
 - case: requires_context_future_result_failed_future
@@ -77,7 +77,7 @@
 
     r: Future[int]
 
-    reveal_type(RequiresContextFutureResult.from_failed_future(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.int*, Any]'
+    reveal_type(RequiresContextFutureResult.from_failed_future(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.int*, Any]"
 
 
 - case: requires_context_future_result_future_result
@@ -88,7 +88,7 @@
 
     r: FutureResult[int, str]
 
-    reveal_type(RequiresContextFutureResult.from_future_result(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, Any]'
+    reveal_type(RequiresContextFutureResult.from_future_result(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, Any]"
 
 
 - case: requires_context_future_result_typecast
@@ -99,7 +99,7 @@
 
     r: RequiresContext[FutureResult[int, str], float]
 
-    reveal_type(RequiresContextFutureResult.from_typecast(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextFutureResult.from_typecast(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, builtins.float*]"
 
 
 - case: requires_context_future_result_successful_context
@@ -109,7 +109,7 @@
 
     r: RequiresContext[str, float]
 
-    reveal_type(RequiresContextFutureResult.from_context(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str*, Any, builtins.float*]'
+    reveal_type(RequiresContextFutureResult.from_context(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str*, Any, builtins.float*]"
 
 
 - case: requires_context_future_result_failed_context
@@ -119,7 +119,7 @@
 
     r: RequiresContext[str, float]
 
-    reveal_type(RequiresContextFutureResult.from_failed_context(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextFutureResult.from_failed_context(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[Any, builtins.str*, builtins.float*]"
 
 
 - case: requires_context_future_result_from_result_context
@@ -129,7 +129,7 @@
 
     r: RequiresContextResult[int, str, float]
 
-    reveal_type(RequiresContextFutureResult.from_result_context(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextFutureResult.from_result_context(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, builtins.float*]"
 
 
 - case: requires_context_future_result_from_ioresult_context
@@ -139,4 +139,4 @@
 
     r: RequiresContextIOResult[int, str, float]
 
-    reveal_type(RequiresContextFutureResult.from_ioresult_context(r))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextFutureResult.from_ioresult_context(r))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int*, builtins.str*, builtins.float*]"

--- a/typesafety/test_context/test_requires_context_ioresult/test_context_ioresult.yml
+++ b/typesafety/test_context/test_requires_context_ioresult/test_context_ioresult.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.context import RequiresContextIOResult
 
-    reveal_type(RequiresContextIOResult.ask())  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[<nothing>, <nothing>, <nothing>]'
+    reveal_type(RequiresContextIOResult.ask())  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[<nothing>, <nothing>, <nothing>]"
 
 
 - case: context_result_io_ask2
@@ -11,4 +11,4 @@
   main: |
     from returns.context import RequiresContextIOResult
 
-    reveal_type(RequiresContextIOResult[int, bool, str].ask())  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str*, builtins.bool*, builtins.str*]'
+    reveal_type(RequiresContextIOResult[int, bool, str].ask())  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str*, builtins.bool*, builtins.str*]"

--- a/typesafety/test_context/test_requires_context_ioresult/test_requires_context_ioresult.yml
+++ b/typesafety/test_context/test_requires_context_ioresult/test_requires_context_ioresult.yml
@@ -5,7 +5,7 @@
 
     x: RequiresContextIOResult[int, float, str]
 
-    reveal_type(x('a'))  # N: Revealed type is 'returns.io.IOResult[builtins.int*, builtins.float*]'
+    reveal_type(x('a'))  # N: Revealed type is "returns.io.IOResult[builtins.int*, builtins.float*]"
 
 
 - case: requires_context_ioresult_getattr
@@ -24,7 +24,7 @@
 
     x: RequiresContextIOResult[int, float, str]
 
-    reveal_type(x.swap())  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float*, builtins.int*, builtins.str*]'
+    reveal_type(x.swap())  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float*, builtins.int*, builtins.str*]"
 
 
 - case: requires_context_ioresult_bind
@@ -37,7 +37,7 @@
     def test(param: int) -> RequiresContextIOResult[bool, float, str]:
         ...
 
-    reveal_type(x.bind(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_ioresult_bind_result
@@ -51,7 +51,7 @@
     def test(param: int) -> Result[bool, float]:
         ...
 
-    reveal_type(x.bind_result(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_result(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_ioresult_bind_ioresult
@@ -65,7 +65,7 @@
     def test(param: int) -> IOResult[bool, float]:
         ...
 
-    reveal_type(x.bind_ioresult(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_ioresult(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_ioresult_bind_io
@@ -79,7 +79,7 @@
     def test(param: int) -> IO[bool]:
         ...
 
-    reveal_type(x.bind_io(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_io(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_ioresult_bind_context
@@ -92,7 +92,7 @@
     def test(param: int) -> RequiresContext[bool, str]:
         ...
 
-    reveal_type(x.bind_context(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_context(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 
@@ -106,7 +106,7 @@
     def test(param: int) -> RequiresContextResult[bool, float, str]:
         ...
 
-    reveal_type(x.bind_context_result(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_context_result(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_ioresult_map
@@ -116,7 +116,7 @@
 
     x: RequiresContextIOResult[int, float, str]
 
-    reveal_type(x.map(bool))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.map(bool))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_ioresult_apply
@@ -128,7 +128,7 @@
     x: RequiresContextIOResult[int, float, str]
     y: RequiresContextIOResult[Callable[[int], bool], float, str]
 
-    reveal_type(x.apply(y))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.apply(y))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_ioresult_lash
@@ -141,7 +141,7 @@
     def test(param: float) -> RequiresContextIOResult[int, bool, str]:
         ...
 
-    reveal_type(x.lash(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool*, builtins.str]'
+    reveal_type(x.lash(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool*, builtins.str]"
 
 
 - case: requires_context_ioresult_alt
@@ -154,7 +154,7 @@
     def test(param: float) -> bool:
         ...
 
-    reveal_type(x.alt(test))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool*, builtins.str]'
+    reveal_type(x.alt(test))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool*, builtins.str]"
 
 
 - case: requires_context_ioresult_modify_env
@@ -163,4 +163,4 @@
     from returns.context import RequiresContextIOResult
 
     first: RequiresContextIOResult[float, bool, int]
-    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is 'returns.io.IOResult[builtins.float*, builtins.bool*]'
+    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is "returns.io.IOResult[builtins.float*, builtins.bool*]"

--- a/typesafety/test_context/test_requires_context_ioresult/test_requires_context_ioresult_cast.yml
+++ b/typesafety/test_context/test_requires_context_ioresult/test_requires_context_ioresult_cast.yml
@@ -4,7 +4,7 @@
     from returns.context import RequiresContextIOResult
 
     first: RequiresContextIOResult[object, Exception, str] = RequiresContextIOResult.from_value(1)
-    reveal_type(first)  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(first)  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_ioresult_failure_cast
@@ -13,7 +13,7 @@
     from returns.context import RequiresContextIOResult
 
     first: RequiresContextIOResult[object, Exception, str] = RequiresContextIOResult.from_failure(TypeError())
-    reveal_type(first)  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(first)  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_ioresult_env_cast
@@ -24,7 +24,7 @@
     first: RequiresContextIOResult[object, Exception, object]
     second: RequiresContextIOResult[object, Exception, str] = first
 
-    reveal_type(second)  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(second)  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_ioresult_wrong_cast

--- a/typesafety/test_context/test_requires_context_ioresult/test_requires_context_ioresult_unit.yml
+++ b/typesafety/test_context/test_requires_context_ioresult/test_requires_context_ioresult_unit.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.context import RequiresContextIOResult
 
-    reveal_type(RequiresContextIOResult.from_value(1))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, Any, Any]'
+    reveal_type(RequiresContextIOResult.from_value(1))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, Any, Any]"
 
 
 - case: requires_context_ioresult_failure
@@ -11,7 +11,7 @@
   main: |
     from returns.context import RequiresContextIOResult
 
-    reveal_type(RequiresContextIOResult.from_failure(1))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[Any, builtins.int*, Any]'
+    reveal_type(RequiresContextIOResult.from_failure(1))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[Any, builtins.int*, Any]"
 
 
 - case: requires_context_ioresult_result
@@ -22,7 +22,7 @@
 
     r: Result[int, str]
 
-    reveal_type(RequiresContextIOResult.from_result(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, Any]'
+    reveal_type(RequiresContextIOResult.from_result(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, Any]"
 
 
 - case: requires_context_ioresult_io
@@ -33,7 +33,7 @@
 
     r: IO[int]
 
-    reveal_type(RequiresContextIOResult.from_io(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, Any, Any]'
+    reveal_type(RequiresContextIOResult.from_io(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, Any, Any]"
 
 
 - case: requires_context_ioresult_failed_io
@@ -44,7 +44,7 @@
 
     r: IO[int]
 
-    reveal_type(RequiresContextIOResult.from_failed_io(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[Any, builtins.int*, Any]'
+    reveal_type(RequiresContextIOResult.from_failed_io(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[Any, builtins.int*, Any]"
 
 
 - case: requires_context_ioresult_ioresult
@@ -55,7 +55,7 @@
 
     r: IOResult[int, str]
 
-    reveal_type(RequiresContextIOResult.from_ioresult(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, Any]'
+    reveal_type(RequiresContextIOResult.from_ioresult(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, Any]"
 
 
 - case: requires_context_ioresult_typecast
@@ -66,7 +66,7 @@
 
     r: RequiresContext[IOResult[int, str], float]
 
-    reveal_type(RequiresContextIOResult.from_typecast(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextIOResult.from_typecast(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, builtins.float*]"
 
 
 - case: requires_context_ioresult_successful_context
@@ -76,7 +76,7 @@
 
     r: RequiresContext[str, float]
 
-    reveal_type(RequiresContextIOResult.from_context(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str*, Any, builtins.float*]'
+    reveal_type(RequiresContextIOResult.from_context(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str*, Any, builtins.float*]"
 
 
 - case: requires_context_ioresult_failed_context
@@ -86,7 +86,7 @@
 
     r: RequiresContext[str, float]
 
-    reveal_type(RequiresContextIOResult.from_failed_context(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[Any, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextIOResult.from_failed_context(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[Any, builtins.str*, builtins.float*]"
 
 
 - case: requires_context_ioresult_from_result_context
@@ -96,4 +96,4 @@
 
     r: RequiresContextResult[int, str, float]
 
-    reveal_type(RequiresContextIOResult.from_result_context(r))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextIOResult.from_result_context(r))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int*, builtins.str*, builtins.float*]"

--- a/typesafety/test_context/test_requires_context_result/test_context_result.yml
+++ b/typesafety/test_context/test_requires_context_result/test_context_result.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.context import RequiresContextResult
 
-    reveal_type(RequiresContextResult.ask())  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[<nothing>, <nothing>, <nothing>]'
+    reveal_type(RequiresContextResult.ask())  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[<nothing>, <nothing>, <nothing>]"
 
 
 - case: context_ask2
@@ -11,4 +11,4 @@
   main: |
     from returns.context import RequiresContextResult
 
-    reveal_type(RequiresContextResult[int, bool, str].ask())  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.str*, builtins.bool*, builtins.str*]'
+    reveal_type(RequiresContextResult[int, bool, str].ask())  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.str*, builtins.bool*, builtins.str*]"

--- a/typesafety/test_context/test_requires_context_result/test_requires_context_cast.yml
+++ b/typesafety/test_context/test_requires_context_result/test_requires_context_cast.yml
@@ -4,7 +4,7 @@
     from returns.context import RequiresContextResult
 
     first: RequiresContextResult[object, Exception, str] = RequiresContextResult.from_value(1)
-    reveal_type(first)  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(first)  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_result_failure_cast
@@ -13,7 +13,7 @@
     from returns.context import RequiresContextResult
 
     first: RequiresContextResult[object, Exception, str] = RequiresContextResult.from_failure(TypeError())
-    reveal_type(first)  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(first)  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_result_env_cast
@@ -24,7 +24,7 @@
     first: RequiresContextResult[object, Exception, object]
     second: RequiresContextResult[object, Exception, str] = first
 
-    reveal_type(second)  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.object, builtins.Exception, builtins.str]'
+    reveal_type(second)  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.object, builtins.Exception, builtins.str]"
 
 
 - case: requires_context_result_wrong_cast

--- a/typesafety/test_context/test_requires_context_result/test_requires_context_result.yml
+++ b/typesafety/test_context/test_requires_context_result/test_requires_context_result.yml
@@ -5,7 +5,7 @@
 
     x: RequiresContextResult[int, Exception, str]
 
-    reveal_type(x('a'))  # N: Revealed type is 'returns.result.Result[builtins.int*, builtins.Exception*]'
+    reveal_type(x('a'))  # N: Revealed type is "returns.result.Result[builtins.int*, builtins.Exception*]"
 
 
 - case: requires_context_result_getattr
@@ -24,7 +24,7 @@
 
     x: RequiresContextResult[int, float, str]
 
-    reveal_type(x.swap())  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.float*, builtins.int*, builtins.str*]'
+    reveal_type(x.swap())  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.float*, builtins.int*, builtins.str*]"
 
 
 - case: requires_context_result_bind
@@ -37,7 +37,7 @@
     def test(param: int) -> RequiresContextResult[bool, float, str]:
         ...
 
-    reveal_type(x.bind(test))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind(test))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_result_bind_result
@@ -51,7 +51,7 @@
     def test(param: int) -> Result[bool, float]:
         ...
 
-    reveal_type(x.bind_result(test))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_result(test))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_result_bind_context
@@ -64,7 +64,7 @@
     def test(param: int) -> RequiresContext[bool, str]:
         ...
 
-    reveal_type(x.bind_context(test))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.bind_context(test))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_result_map
@@ -74,7 +74,7 @@
 
     x: RequiresContextResult[int, float, str]
 
-    reveal_type(x.map(bool))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.map(bool))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_result_apply
@@ -86,7 +86,7 @@
     x: RequiresContextResult[int, float, str]
     y: RequiresContextResult[Callable[[int], bool], float, str]
 
-    reveal_type(x.apply(y))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]'
+    reveal_type(x.apply(y))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.bool*, builtins.float, builtins.str]"
 
 
 - case: requires_context_result_lash
@@ -99,7 +99,7 @@
     def test(param: float) -> RequiresContextResult[int, bool, str]:
         ...
 
-    reveal_type(x.lash(test))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.bool*, builtins.str]'
+    reveal_type(x.lash(test))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.bool*, builtins.str]"
 
 
 - case: requires_context_result_alt
@@ -112,7 +112,7 @@
     def test(param: float) -> bool:
         ...
 
-    reveal_type(x.alt(test))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.bool*, builtins.str]'
+    reveal_type(x.alt(test))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.bool*, builtins.str]"
 
 
 - case: requires_context_result_modify_env
@@ -121,4 +121,4 @@
     from returns.context import RequiresContextResult
 
     first: RequiresContextResult[float, bool, int]
-    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is 'returns.result.Result[builtins.float*, builtins.bool*]'
+    reveal_type(first.modify_env(int)('1'))  # N: Revealed type is "returns.result.Result[builtins.float*, builtins.bool*]"

--- a/typesafety/test_context/test_requires_context_result/test_requires_context_result_unit.yml
+++ b/typesafety/test_context/test_requires_context_result/test_requires_context_result_unit.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.context import RequiresContextResult
 
-    reveal_type(RequiresContextResult.from_value(1))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int*, Any, Any]'
+    reveal_type(RequiresContextResult.from_value(1))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int*, Any, Any]"
 
 
 - case: requires_context_result_failure
@@ -11,7 +11,7 @@
   main: |
     from returns.context import RequiresContextResult
 
-    reveal_type(RequiresContextResult.from_failure(1))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[Any, builtins.int*, Any]'
+    reveal_type(RequiresContextResult.from_failure(1))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[Any, builtins.int*, Any]"
 
 
 - case: requires_context_result_result
@@ -22,7 +22,7 @@
 
     r: Result[int, str]
 
-    reveal_type(RequiresContextResult.from_result(r))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int*, builtins.str*, Any]'
+    reveal_type(RequiresContextResult.from_result(r))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int*, builtins.str*, Any]"
 
 
 - case: requires_context_result_typecast
@@ -33,7 +33,7 @@
 
     r: RequiresContext[Result[int, str], float]
 
-    reveal_type(RequiresContextResult.from_typecast(r))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int*, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextResult.from_typecast(r))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int*, builtins.str*, builtins.float*]"
 
 
 - case: requires_context_result_successful_context
@@ -43,7 +43,7 @@
 
     r: RequiresContext[str, float]
 
-    reveal_type(RequiresContextResult.from_context(r))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.str*, Any, builtins.float*]'
+    reveal_type(RequiresContextResult.from_context(r))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.str*, Any, builtins.float*]"
 
 
 - case: requires_context_result_failed_context
@@ -53,4 +53,4 @@
 
     r: RequiresContext[str, float]
 
-    reveal_type(RequiresContextResult.from_failed_context(r))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[Any, builtins.str*, builtins.float*]'
+    reveal_type(RequiresContextResult.from_failed_context(r))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[Any, builtins.str*, builtins.float*]"

--- a/typesafety/test_contrib/test_hypothesis/test_laws/test_check_all_laws.yml
+++ b/typesafety/test_contrib/test_hypothesis/test_laws/test_check_all_laws.yml
@@ -31,4 +31,4 @@
   main: |
     from returns.contrib.hypothesis.laws import check_all_laws
 
-    reveal_type(check_all_laws)  # N: Revealed type is 'def (container_type: Type[returns.primitives.laws.Lawful[Any]], *, settings_kwargs: Union[builtins.dict[builtins.str, Any], None] =, use_init: builtins.bool =)'
+    reveal_type(check_all_laws)  # N: Revealed type is "def (container_type: Type[returns.primitives.laws.Lawful[Any]], *, settings_kwargs: Union[builtins.dict[builtins.str, Any], None] =, use_init: builtins.bool =)"

--- a/typesafety/test_converters/test_flatten.yml
+++ b/typesafety/test_converters/test_flatten.yml
@@ -26,7 +26,7 @@
 
     x: Result[Result[int, str], float]
     # TODO: I am pretty sure we can later fix this to be an error:
-    reveal_type(flatten(x))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.object]'
+    reveal_type(flatten(x))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.object]"
 
 
 - case: flatten_custom_type
@@ -43,7 +43,7 @@
         ...
 
     x: MyClass[MyClass[int]]
-    reveal_type(flatten(x))  # N: Revealed type is 'main.MyClass[builtins.int]'
+    reveal_type(flatten(x))  # N: Revealed type is "main.MyClass[builtins.int]"
 
 
 - case: flatten_wrong_flatten_error_type
@@ -66,7 +66,7 @@
     from returns.converters import flatten
     from returns.io import IO
 
-    reveal_type(flatten(IO(IO(1))))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(flatten(IO(IO(1))))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 
 - case: flatten_maybe
@@ -75,7 +75,7 @@
     from returns.converters import flatten
     from returns.maybe import Some
 
-    reveal_type(flatten(Some(Some(1))))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int]'
+    reveal_type(flatten(Some(Some(1))))  # N: Revealed type is "returns.maybe.Maybe[builtins.int]"
 
 
 - case: flatten_result
@@ -87,7 +87,7 @@
     def returns_result() -> Result[Result[int, str], str]:
         ...
 
-    reveal_type(flatten(returns_result()))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(flatten(returns_result()))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: flatten_ioresult
@@ -99,7 +99,7 @@
     def returns_ioresult() -> IOResult[IOResult[int, str], str]:
         ...
 
-    reveal_type(flatten(returns_ioresult()))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(flatten(returns_ioresult()))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: flatten_context
@@ -110,7 +110,7 @@
 
     x: RequiresContext[RequiresContext[str, int], int]
 
-    reveal_type(flatten(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.str, builtins.int]'
+    reveal_type(flatten(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.str, builtins.int]"
 
 
 - case: flatten_context_result
@@ -121,7 +121,7 @@
 
     x: RequiresContextResult[RequiresContextResult[str, int, float], int, float]
 
-    reveal_type(flatten(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.str, builtins.int, builtins.float]'
+    reveal_type(flatten(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.str, builtins.int, builtins.float]"
 
 
 - case: flatten_context_ioresult
@@ -132,7 +132,7 @@
 
     x: RequiresContextIOResult[RequiresContextIOResult[str, int, float], int, float]
 
-    reveal_type(flatten(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.int, builtins.float]'
+    reveal_type(flatten(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.int, builtins.float]"
 
 
 - case: flatten_context_ioresult
@@ -143,7 +143,7 @@
 
     x: RequiresContextIOResult[RequiresContextIOResult[str, int, float], int, float]
 
-    reveal_type(flatten(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.int, builtins.float]'
+    reveal_type(flatten(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.int, builtins.float]"
 
 
 - case: flatten_future_result
@@ -154,7 +154,7 @@
 
     x: ReaderFutureResult[ReaderFutureResult[int, bool, str], bool, str]
 
-    reveal_type(flatten(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(flatten(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: flatten_future_result
@@ -165,4 +165,4 @@
 
     x: FutureResult[FutureResult[int, str], str]
 
-    reveal_type(flatten(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(flatten(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"

--- a/typesafety/test_converters/test_maybe_to_result.yml
+++ b/typesafety/test_converters/test_maybe_to_result.yml
@@ -4,4 +4,4 @@
     from returns.converters import maybe_to_result
     from returns.maybe import Maybe
 
-    reveal_type(maybe_to_result(Maybe.from_value(1)))  # N: Revealed type is 'returns.result.Result[builtins.int*, None]'
+    reveal_type(maybe_to_result(Maybe.from_value(1)))  # N: Revealed type is "returns.result.Result[builtins.int*, None]"

--- a/typesafety/test_converters/test_result_to_maybe.yml
+++ b/typesafety/test_converters/test_result_to_maybe.yml
@@ -7,4 +7,4 @@
     def returns_result() -> Result[int, str]:
         ...
 
-    reveal_type(result_to_maybe(returns_result()))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int*]'
+    reveal_type(result_to_maybe(returns_result()))  # N: Revealed type is "returns.maybe.Maybe[builtins.int*]"

--- a/typesafety/test_curry/test_curry/test_curry.yml
+++ b/typesafety/test_curry/test_curry/test_curry.yml
@@ -7,8 +7,8 @@
     def zero() -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'def () -> builtins.str'
-    reveal_type(zero())  # N: Revealed type is 'builtins.str'
+    reveal_type(zero)  # N: Revealed type is "def () -> builtins.str"
+    reveal_type(zero())  # N: Revealed type is "builtins.str"
 
 
 - case: curry_single_arg
@@ -20,8 +20,8 @@
     def zero(arg: int) -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'def (arg: builtins.int) -> builtins.str'
-    reveal_type(zero(1))  # N: Revealed type is 'builtins.str'
+    reveal_type(zero)  # N: Revealed type is "def (arg: builtins.int) -> builtins.str"
+    reveal_type(zero(1))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_two_args1
@@ -33,10 +33,10 @@
     def zero(arg: int, other: float) -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'Overload(def (arg: builtins.int) -> def (other: builtins.float) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> builtins.str)'
-    reveal_type(zero(1))  # N: Revealed type is 'def (other: builtins.float) -> builtins.str'
-    reveal_type(zero(1, 2.0))  # N: Revealed type is 'builtins.str'
-    reveal_type(zero(1)(2.0))  # N: Revealed type is 'builtins.str'
+    reveal_type(zero)  # N: Revealed type is "Overload(def (arg: builtins.int) -> def (other: builtins.float) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> builtins.str)"
+    reveal_type(zero(1))  # N: Revealed type is "def (other: builtins.float) -> builtins.str"
+    reveal_type(zero(1, 2.0))  # N: Revealed type is "builtins.str"
+    reveal_type(zero(1)(2.0))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_two_args2
@@ -47,10 +47,10 @@
     def zero(arg: int, other: float) -> str:
         ...
 
-    reveal_type(curry(zero))  # N: Revealed type is 'Overload(def (arg: builtins.int) -> def (other: builtins.float) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> builtins.str)'
-    reveal_type(curry(zero)(1))  # N: Revealed type is 'def (other: builtins.float) -> builtins.str'
-    reveal_type(curry(zero)(1, 2.0))  # N: Revealed type is 'builtins.str'
-    reveal_type(curry(zero)(1)(2.0))  # N: Revealed type is 'builtins.str'
+    reveal_type(curry(zero))  # N: Revealed type is "Overload(def (arg: builtins.int) -> def (other: builtins.float) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> builtins.str)"
+    reveal_type(curry(zero)(1))  # N: Revealed type is "def (other: builtins.float) -> builtins.str"
+    reveal_type(curry(zero)(1, 2.0))  # N: Revealed type is "builtins.str"
+    reveal_type(curry(zero)(1)(2.0))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_two_args3
@@ -70,17 +70,17 @@
     main:7: note:     <1 more non-matching overload not shown>
     main:7: note:     def zero(arg: int) -> Callable[..., str]
     main:7: note: Possible overload variant:
-    main:7: note: Revealed type is 'Any'
+    main:7: note: Revealed type is "Any"
     main:8: error: No overload variant of "zero" matches argument types "float", "int"
     main:8: note:     <1 more non-matching overload not shown>
     main:8: note:     def zero(arg: int, other: float) -> str
     main:8: note: Possible overload variant:
-    main:8: note: Revealed type is 'Any'
+    main:8: note: Revealed type is "Any"
     main:9: error: No overload variant of "zero" matches argument types "int", "float", "float"
     main:9: note:     def zero(arg: int) -> Callable[..., str]
     main:9: note:     def zero(arg: int, other: float) -> str
     main:9: note: Possible overload variants:
-    main:9: note: Revealed type is 'Any'
+    main:9: note: Revealed type is "Any"
 
 - case: curry_two_args_one_default
   disable_cache: false
@@ -91,10 +91,10 @@
     def zero(arg: int, other: float = 1.0) -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'Overload(def (arg: builtins.int) -> def (other: builtins.float =) -> builtins.str, def (arg: builtins.int, other: builtins.float =) -> builtins.str)'
-    reveal_type(zero(1))  # N: Revealed type is 'def (other: builtins.float =) -> builtins.str'
-    reveal_type(zero(1, 2.0))  # N: Revealed type is 'builtins.str'
-    reveal_type(zero(1)(2.0))  # N: Revealed type is 'builtins.str'
+    reveal_type(zero)  # N: Revealed type is "Overload(def (arg: builtins.int) -> def (other: builtins.float =) -> builtins.str, def (arg: builtins.int, other: builtins.float =) -> builtins.str)"
+    reveal_type(zero(1))  # N: Revealed type is "def (other: builtins.float =) -> builtins.str"
+    reveal_type(zero(1, 2.0))  # N: Revealed type is "builtins.str"
+    reveal_type(zero(1)(2.0))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_three_args
@@ -106,10 +106,10 @@
     def zero(arg: int, other: float, *, kw: bool) -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'Overload(def (arg: builtins.int) -> Overload(def (other: builtins.float, *, kw: builtins.bool) -> builtins.str, def (other: builtins.float) -> def (*, kw: builtins.bool) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (*, kw: builtins.bool) -> builtins.str, def (arg: builtins.int, other: builtins.float, *, kw: builtins.bool) -> builtins.str)'
-    reveal_type(zero(1))  # N: Revealed type is 'Overload(def (other: builtins.float, *, kw: builtins.bool) -> builtins.str, def (other: builtins.float) -> def (*, kw: builtins.bool) -> builtins.str)'
-    reveal_type(zero(1, 2.0))  # N: Revealed type is 'def (*, kw: builtins.bool) -> builtins.str'
-    reveal_type(zero(1)(2.0))  # N: Revealed type is 'def (*, kw: builtins.bool) -> builtins.str'
-    reveal_type(zero(1, 2.0)(kw=True))  # N: Revealed type is 'builtins.str'
-    reveal_type(zero(1)(2.0)(kw=True))  # N: Revealed type is 'builtins.str'
-    reveal_type(zero(1, 2.0, kw=True))  # N: Revealed type is 'builtins.str'
+    reveal_type(zero)  # N: Revealed type is "Overload(def (arg: builtins.int) -> Overload(def (other: builtins.float, *, kw: builtins.bool) -> builtins.str, def (other: builtins.float) -> def (*, kw: builtins.bool) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (*, kw: builtins.bool) -> builtins.str, def (arg: builtins.int, other: builtins.float, *, kw: builtins.bool) -> builtins.str)"
+    reveal_type(zero(1))  # N: Revealed type is "Overload(def (other: builtins.float, *, kw: builtins.bool) -> builtins.str, def (other: builtins.float) -> def (*, kw: builtins.bool) -> builtins.str)"
+    reveal_type(zero(1, 2.0))  # N: Revealed type is "def (*, kw: builtins.bool) -> builtins.str"
+    reveal_type(zero(1)(2.0))  # N: Revealed type is "def (*, kw: builtins.bool) -> builtins.str"
+    reveal_type(zero(1, 2.0)(kw=True))  # N: Revealed type is "builtins.str"
+    reveal_type(zero(1)(2.0)(kw=True))  # N: Revealed type is "builtins.str"
+    reveal_type(zero(1, 2.0, kw=True))  # N: Revealed type is "builtins.str"

--- a/typesafety/test_curry/test_curry/test_curry_args_kwargs.yml
+++ b/typesafety/test_curry/test_curry/test_curry_args_kwargs.yml
@@ -7,7 +7,7 @@
     def zero(*args) -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'Any'
+    reveal_type(zero)  # N: Revealed type is "Any"
 
 
 - case: curry_kwargs
@@ -19,7 +19,7 @@
     def zero(**kwargs) -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'Any'
+    reveal_type(zero)  # N: Revealed type is "Any"
 
 
 - case: curry_args_kwargs
@@ -31,4 +31,4 @@
     def zero(*args, **kwargs) -> str:
         ...
 
-    reveal_type(zero)  # N: Revealed type is 'Any'
+    reveal_type(zero)  # N: Revealed type is "Any"

--- a/typesafety/test_curry/test_curry/test_curry_arguments.yml
+++ b/typesafety/test_curry/test_curry/test_curry_arguments.yml
@@ -14,7 +14,7 @@
     ) -> str:
         ...
 
-    reveal_type(multiple)  # N: Revealed type is 'Overload(def (builtins.int) -> Overload(def (builtins.int, builtins.int, d: builtins.int) -> builtins.str, def (builtins.int, builtins.int) -> def (d: builtins.int) -> builtins.str, def (builtins.int) -> Overload(def (builtins.int, d: builtins.int) -> builtins.str, def (builtins.int) -> def (d: builtins.int) -> builtins.str)), def (builtins.int, builtins.int) -> Overload(def (builtins.int, d: builtins.int) -> builtins.str, def (builtins.int) -> def (d: builtins.int) -> builtins.str), def (builtins.int, builtins.int, builtins.int) -> def (d: builtins.int) -> builtins.str, def (builtins.int, builtins.int, builtins.int, d: builtins.int) -> builtins.str)'
+    reveal_type(multiple)  # N: Revealed type is "Overload(def (builtins.int) -> Overload(def (builtins.int, builtins.int, d: builtins.int) -> builtins.str, def (builtins.int, builtins.int) -> def (d: builtins.int) -> builtins.str, def (builtins.int) -> Overload(def (builtins.int, d: builtins.int) -> builtins.str, def (builtins.int) -> def (d: builtins.int) -> builtins.str)), def (builtins.int, builtins.int) -> Overload(def (builtins.int, d: builtins.int) -> builtins.str, def (builtins.int) -> def (d: builtins.int) -> builtins.str), def (builtins.int, builtins.int, builtins.int) -> def (d: builtins.int) -> builtins.str, def (builtins.int, builtins.int, builtins.int, d: builtins.int) -> builtins.str)"
 
 
 - case: curry_nested_overload1
@@ -35,7 +35,7 @@
     def test(a: int, b: int) -> float:
         ...
 
-    reveal_type(MyClass(test))  # N: Revealed type is 'main.MyClass[Overload(def (a: builtins.int) -> def (b: builtins.int) -> builtins.float, def (a: builtins.int, b: builtins.int) -> builtins.float)]'
+    reveal_type(MyClass(test))  # N: Revealed type is "main.MyClass[Overload(def (a: builtins.int) -> def (b: builtins.int) -> builtins.float, def (a: builtins.int, b: builtins.int) -> builtins.float)]"
 
 
 - case: curry_nested_overload2
@@ -56,7 +56,7 @@
     def test(a: int, b: int, c: str) -> int:
         ...
 
-    reveal_type(MyClass(test))  # N: Revealed type is 'main.MyClass[Overload(def (a: builtins.int) -> Overload(def (b: builtins.int, c: builtins.str) -> builtins.int, def (b: builtins.int) -> def (c: builtins.str) -> builtins.int), def (a: builtins.int, b: builtins.int) -> def (c: builtins.str) -> builtins.int, def (a: builtins.int, b: builtins.int, c: builtins.str) -> builtins.int)]'
+    reveal_type(MyClass(test))  # N: Revealed type is "main.MyClass[Overload(def (a: builtins.int) -> Overload(def (b: builtins.int, c: builtins.str) -> builtins.int, def (b: builtins.int) -> def (c: builtins.str) -> builtins.int), def (a: builtins.int, b: builtins.int) -> def (c: builtins.str) -> builtins.int, def (a: builtins.int, b: builtins.int, c: builtins.str) -> builtins.int)]"
 
 
 # TODO: remove skip after this bug in `mypy` is fixed:
@@ -72,7 +72,7 @@
         def __init__(self, arg: int, other: str) -> None:
             ...
 
-    reveal_type(Test)  # N: Revealed type is 'Overload(def (arg: builtins.int) -> def (other: builtins.str) -> ex.Test, def (arg: builtins.int, other: builtins.str) -> ex.Test)'
+    reveal_type(Test)  # N: Revealed type is "Overload(def (arg: builtins.int) -> def (other: builtins.str) -> ex.Test, def (arg: builtins.int, other: builtins.str) -> ex.Test)"
 
 
 - case: curry_call_magic_method
@@ -85,7 +85,7 @@
         def __call__(self, arg: int, other: float, last: str) -> str:
             ...
 
-    reveal_type(Test()(1))  # N: Revealed type is 'Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)'
+    reveal_type(Test()(1))  # N: Revealed type is "Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)"
 
 
 - case: curry_classmethod1
@@ -99,11 +99,11 @@
         def some(cls, arg: int, other: float, last: str) -> str:
             ...
 
-    reveal_type(Test.some)  # N: Revealed type is 'Overload(def () -> Overload(def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)), def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)'
+    reveal_type(Test.some)  # N: Revealed type is "Overload(def () -> Overload(def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)), def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)"
 
-    reveal_type(Test.some(1))  # N: Revealed type is 'Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)'
+    reveal_type(Test.some(1))  # N: Revealed type is "Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)"
 
-    reveal_type(Test.some(1, 2.0, 'a'))  # N: Revealed type is 'builtins.str'
+    reveal_type(Test.some(1, 2.0, 'a'))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_classmethod2
@@ -121,7 +121,7 @@
     def test(c: Callable[[int, str], str]) -> str:
         return c(1, 'a')
 
-    reveal_type(test(Test.some))  # N: Revealed type is 'builtins.str'
+    reveal_type(test(Test.some))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_classmethod3
@@ -139,7 +139,7 @@
     def test(c: Callable[[int, str], str]) -> str:
         return c(1, 'a')
 
-    reveal_type(test(Test.some('a')))  # N: Revealed type is 'builtins.str'
+    reveal_type(test(Test.some('a')))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_staticmethod
@@ -153,7 +153,7 @@
         def some(arg: int, other: float, last: str) -> str:
             ...
 
-    reveal_type(Test.some)  # N: Revealed type is 'Overload(def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)'
+    reveal_type(Test.some)  # N: Revealed type is "Overload(def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)"
 
 
 - case: curry_regular_method
@@ -166,13 +166,13 @@
         def some(self, arg: int, other: float, last: str) -> str:
             ...
 
-    reveal_type(Test.some)  # N: Revealed type is 'Overload(def (self: main.Test) -> Overload(def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)), def (self: main.Test, arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (self: main.Test, arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (self: main.Test, arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)'
+    reveal_type(Test.some)  # N: Revealed type is "Overload(def (self: main.Test) -> Overload(def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)), def (self: main.Test, arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (self: main.Test, arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (self: main.Test, arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)"
 
-    reveal_type(Test.some(Test(), 1))  # N: Revealed type is 'Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)'
+    reveal_type(Test.some(Test(), 1))  # N: Revealed type is "Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)"
 
-    reveal_type(Test().some)  # N: Revealed type is 'Overload(def () -> Overload(def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)), def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)'
+    reveal_type(Test().some)  # N: Revealed type is "Overload(def () -> Overload(def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)), def (arg: builtins.int) -> Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str), def (arg: builtins.int, other: builtins.float) -> def (last: builtins.str) -> builtins.str, def (arg: builtins.int, other: builtins.float, last: builtins.str) -> builtins.str)"
 
-    reveal_type(Test().some(1))  # N: Revealed type is 'Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)'
+    reveal_type(Test().some(1))  # N: Revealed type is "Overload(def (other: builtins.float, last: builtins.str) -> builtins.str, def (other: builtins.float) -> def (last: builtins.str) -> builtins.str)"
 
 
 - case: curry_match_callable_protocol1
@@ -189,7 +189,7 @@
     def test(c: Callable[[int, str], str]) -> str:
         return c(1, 'a')
 
-    reveal_type(test(Test().some(1)))  # N: Revealed type is 'builtins.str'
+    reveal_type(test(Test().some(1)))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_match_callable_protocol2
@@ -206,7 +206,7 @@
     def test(c: Callable[[int, str], str]) -> str:
         return c(1, 'a')
 
-    reveal_type(test(Test().some))  # N: Revealed type is 'builtins.str'
+    reveal_type(test(Test().some))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_match_callable_protocol3
@@ -223,7 +223,7 @@
     def test(c: Callable[[int], Callable[[float], str]]) -> str:
         return c(1)(5.0)
 
-    reveal_type(test(Test().some))  # N: Revealed type is 'builtins.str'
+    reveal_type(test(Test().some))  # N: Revealed type is "builtins.str"
 
 
 - case: curry_match_callable_protocol4
@@ -241,4 +241,4 @@
     def test(c: Callable[[int], Callable[[float], str]]) -> str:
         return c(1)(5.0)
 
-    reveal_type(test(Test.some))  # N: Revealed type is 'builtins.str'
+    reveal_type(test(Test.some))  # N: Revealed type is "builtins.str"

--- a/typesafety/test_curry/test_curry/test_curry_generics.yml
+++ b/typesafety/test_curry/test_curry/test_curry_generics.yml
@@ -12,8 +12,8 @@
 
     x: List[int]
 
-    reveal_type(zero)  # N: Revealed type is 'def [T] (arg: builtins.list[T`-1]) -> T`-1'
-    reveal_type(zero(x))  # N: Revealed type is 'builtins.int*'
+    reveal_type(zero)  # N: Revealed type is "def [T] (arg: builtins.list[T`-1]) -> T`-1"
+    reveal_type(zero(x))  # N: Revealed type is "builtins.int*"
 
 
 - case: curry_two_generic_args1
@@ -30,10 +30,10 @@
 
     x: List[int]
 
-    reveal_type(zero)  # N: Revealed type is 'Overload(def [T] (arg: builtins.list[T`-1]) -> def (other: builtins.int) -> T`-1, def [T] (arg: builtins.list[T`-1], other: builtins.int) -> T`-1)'
-    reveal_type(zero(x))  # N: Revealed type is 'def (other: builtins.int) -> builtins.int*'
-    reveal_type(zero(x)(1))  # N: Revealed type is 'builtins.int*'
-    reveal_type(zero(x, 1))  # N: Revealed type is 'builtins.int*'
+    reveal_type(zero)  # N: Revealed type is "Overload(def [T] (arg: builtins.list[T`-1]) -> def (other: builtins.int) -> T`-1, def [T] (arg: builtins.list[T`-1], other: builtins.int) -> T`-1)"
+    reveal_type(zero(x))  # N: Revealed type is "def (other: builtins.int) -> builtins.int*"
+    reveal_type(zero(x)(1))  # N: Revealed type is "builtins.int*"
+    reveal_type(zero(x, 1))  # N: Revealed type is "builtins.int*"
 
 
 - case: curry_two_generic_args2
@@ -50,10 +50,10 @@
 
     x: List[int]
 
-    reveal_type(zero)  # N: Revealed type is 'Overload(def (arg: builtins.int) -> def [T] (other: builtins.list[T`-1]) -> T`-1, def [T] (arg: builtins.int, other: builtins.list[T`-1]) -> T`-1)'
-    reveal_type(zero(1))  # N: Revealed type is 'def [T] (other: builtins.list[T`-1]) -> T`-1'
-    reveal_type(zero(1)(x))  # N: Revealed type is 'builtins.int*'
-    reveal_type(zero(1, x))  # N: Revealed type is 'builtins.int*'
+    reveal_type(zero)  # N: Revealed type is "Overload(def (arg: builtins.int) -> def [T] (other: builtins.list[T`-1]) -> T`-1, def [T] (arg: builtins.int, other: builtins.list[T`-1]) -> T`-1)"
+    reveal_type(zero(1))  # N: Revealed type is "def [T] (other: builtins.list[T`-1]) -> T`-1"
+    reveal_type(zero(1)(x))  # N: Revealed type is "builtins.int*"
+    reveal_type(zero(1, x))  # N: Revealed type is "builtins.int*"
 
 
 - case: curry_two_generic_args3
@@ -70,7 +70,7 @@
 
     x: List[int]
 
-    reveal_type(zero)  # N: Revealed type is 'Overload(def [T] (arg: T`-1) -> def [T] (other: builtins.list[T`-1]) -> T`-1, def [T] (arg: T`-1, other: builtins.list[T`-1]) -> T`-1)'
-    reveal_type(zero(1))  # N: Revealed type is 'def [T] (other: builtins.list[builtins.int*]) -> builtins.int*'
-    reveal_type(zero(1)(x))  # N: Revealed type is 'builtins.int'
-    reveal_type(zero(1, x))  # N: Revealed type is 'builtins.int*'
+    reveal_type(zero)  # N: Revealed type is "Overload(def [T] (arg: T`-1) -> def [T] (other: builtins.list[T`-1]) -> T`-1, def [T] (arg: T`-1, other: builtins.list[T`-1]) -> T`-1)"
+    reveal_type(zero(1))  # N: Revealed type is "def [T] (other: builtins.list[builtins.int*]) -> builtins.int*"
+    reveal_type(zero(1)(x))  # N: Revealed type is "builtins.int"
+    reveal_type(zero(1, x))  # N: Revealed type is "builtins.int*"

--- a/typesafety/test_curry/test_partial/test_partial.yml
+++ b/typesafety/test_curry/test_partial/test_partial.yml
@@ -6,7 +6,7 @@
     def two_args(first: int, second: float) -> str:
         ...
 
-    reveal_type(partial(two_args))  # N: Revealed type is 'def (first: builtins.int, second: builtins.float) -> builtins.str'
+    reveal_type(partial(two_args))  # N: Revealed type is "def (first: builtins.int, second: builtins.float) -> builtins.str"
 
 
 - case: partial_single_arg
@@ -17,7 +17,7 @@
     def two_args(first: int, second: float) -> str:
         ...
 
-    reveal_type(partial(two_args, 1))  # N: Revealed type is 'def (second: builtins.float) -> builtins.str'
+    reveal_type(partial(two_args, 1))  # N: Revealed type is "def (second: builtins.float) -> builtins.str"
 
 
 - case: partial_all_args
@@ -28,7 +28,7 @@
     def two_args(first: int, second: float) -> str:
         ...
 
-    reveal_type(partial(two_args, 1, second=0.5))  # N: Revealed type is 'def () -> builtins.str'
+    reveal_type(partial(two_args, 1, second=0.5))  # N: Revealed type is "def () -> builtins.str"
 
 
 - case: partial_single_named_arg
@@ -39,7 +39,7 @@
     def two_args(first: int, second: float) -> str:
         ...
 
-    reveal_type(partial(two_args, second=1.0))  # N: Revealed type is 'def (first: builtins.int) -> builtins.str'
+    reveal_type(partial(two_args, second=1.0))  # N: Revealed type is "def (first: builtins.int) -> builtins.str"
 
 
 - case: partial_multiple_args
@@ -57,7 +57,7 @@
     ) -> str:
         ...
 
-    reveal_type(partial(multiple, 1, 0.4, flag3=int, flag2=True))  # N: Revealed type is 'def (third: builtins.str, flag1: builtins.bool) -> builtins.str'
+    reveal_type(partial(multiple, 1, 0.4, flag3=int, flag2=True))  # N: Revealed type is "def (third: builtins.str, flag1: builtins.bool) -> builtins.str"
 
 
 - case: partial_not_callable_type
@@ -67,7 +67,7 @@
 
     curried_int = partial(int, 10)
 
-    reveal_type(curried_int)  # N: Revealed type is 'def () -> builtins.int'
+    reveal_type(curried_int)  # N: Revealed type is "def () -> builtins.int"
 
 
 - case: partial_explicit_noreturn
@@ -79,7 +79,7 @@
     def exit(x: int) -> NoReturn:
         ...
 
-    reveal_type(partial(exit, 1))  # N: Revealed type is 'def () -> <nothing>'
+    reveal_type(partial(exit, 1))  # N: Revealed type is "def () -> <nothing>"
 
 
 - case: partial_wrong_argument_types
@@ -149,4 +149,4 @@
         default: _SecondType,
         function: Callable[[_SecondType, _FirstType], _SecondType],
     ):
-        reveal_type(partial(function, default))  # N: Revealed type is 'def (_FirstType`-2) -> _SecondType`-1'
+        reveal_type(partial(function, default))  # N: Revealed type is "def (_FirstType`-2) -> _SecondType`-1"

--- a/typesafety/test_curry/test_partial/test_partial_arguments.yml
+++ b/typesafety/test_curry/test_partial/test_partial_arguments.yml
@@ -25,16 +25,16 @@
     reveal_type(partial(multiple, 1, 2, 3, 4.0, 5.0))
     reveal_type(partial(multiple, 1, 2, 3, m='m', q='q', long='long'))
   out: |
-    main:14: note: Revealed type is 'def (a: builtins.int, b: builtins.int, c: builtins.int =, *args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
-    main:15: note: Revealed type is 'def (b: builtins.int, c: builtins.int =, *args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
-    main:16: note: Revealed type is 'def (c: builtins.int =, *args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
-    main:17: note: Revealed type is 'def (*args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
-    main:18: note: Revealed type is 'def (*args: builtins.float, *, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
-    main:19: note: Revealed type is 'def (*args: builtins.float, *, d: builtins.str, **kwargs: builtins.str) -> builtins.str'
-    main:20: note: Revealed type is 'def (c: builtins.int =, *args: builtins.float, *, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
-    main:21: note: Revealed type is 'def (c: builtins.int =, *args: builtins.float, *, d: builtins.str, **kwargs: builtins.str) -> builtins.str'
-    main:22: note: Revealed type is 'def (*args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
-    main:23: note: Revealed type is 'def (*args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str'
+    main:14: note: Revealed type is "def (a: builtins.int, b: builtins.int, c: builtins.int =, *args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
+    main:15: note: Revealed type is "def (b: builtins.int, c: builtins.int =, *args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
+    main:16: note: Revealed type is "def (c: builtins.int =, *args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
+    main:17: note: Revealed type is "def (*args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
+    main:18: note: Revealed type is "def (*args: builtins.float, *, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
+    main:19: note: Revealed type is "def (*args: builtins.float, *, d: builtins.str, **kwargs: builtins.str) -> builtins.str"
+    main:20: note: Revealed type is "def (c: builtins.int =, *args: builtins.float, *, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
+    main:21: note: Revealed type is "def (c: builtins.int =, *args: builtins.float, *, d: builtins.str, **kwargs: builtins.str) -> builtins.str"
+    main:22: note: Revealed type is "def (*args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
+    main:23: note: Revealed type is "def (*args: builtins.float, *, d: builtins.str, e: builtins.bool =, **kwargs: builtins.str) -> builtins.str"
 
 
 - case: partial_args_kwargs
@@ -48,7 +48,7 @@
     ) -> str:
         ...
 
-    reveal_type(partial(multiple, 1, 2, 3, x='x', y='y')(4, 5, z='z'))  # N: Revealed type is 'builtins.str'
+    reveal_type(partial(multiple, 1, 2, 3, x='x', y='y')(4, 5, z='z'))  # N: Revealed type is "builtins.str"
 
 
 - case: partial_pos_only_args
@@ -66,11 +66,11 @@
     ) -> str:
         ...
 
-    reveal_type(partial(multiple, 1))  # N: Revealed type is 'def (builtins.int, builtins.int, d: builtins.int) -> builtins.str'
-    reveal_type(partial(multiple, 1, 2))  # N: Revealed type is 'def (builtins.int, d: builtins.int) -> builtins.str'
-    reveal_type(partial(multiple, 1, 2, 3))  # N: Revealed type is 'def (d: builtins.int) -> builtins.str'
-    reveal_type(partial(multiple, 1, 2, d=4))  # N: Revealed type is 'def (builtins.int) -> builtins.str'
-    reveal_type(partial(multiple, 1, 2, 3, d=4))  # N: Revealed type is 'def () -> builtins.str'
+    reveal_type(partial(multiple, 1))  # N: Revealed type is "def (builtins.int, builtins.int, d: builtins.int) -> builtins.str"
+    reveal_type(partial(multiple, 1, 2))  # N: Revealed type is "def (builtins.int, d: builtins.int) -> builtins.str"
+    reveal_type(partial(multiple, 1, 2, 3))  # N: Revealed type is "def (d: builtins.int) -> builtins.str"
+    reveal_type(partial(multiple, 1, 2, d=4))  # N: Revealed type is "def (builtins.int) -> builtins.str"
+    reveal_type(partial(multiple, 1, 2, 3, d=4))  # N: Revealed type is "def () -> builtins.str"
 
 
 - case: partial_object
@@ -90,10 +90,10 @@
     reveal_type(partial(Inst(1)))
     reveal_type(partial(Inst(1), 1))
   out: |
-    main:10: note: Revealed type is 'def (arg: builtins.int) -> main.Inst'
-    main:11: note: Revealed type is 'def () -> main.Inst'
-    main:12: note: Revealed type is 'main.Inst'
-    main:13: note: Revealed type is 'def () -> builtins.int'
+    main:10: note: Revealed type is "def (arg: builtins.int) -> main.Inst"
+    main:11: note: Revealed type is "def () -> main.Inst"
+    main:12: note: Revealed type is "main.Inst"
+    main:13: note: Revealed type is "def () -> builtins.int"
 
 
 - case: partial_classmethod
@@ -106,7 +106,7 @@
         def some(cls, arg: int, other: str) -> float:
             ...
 
-    reveal_type(partial(Test.some, 1))  # N: Revealed type is 'def (other: builtins.str) -> builtins.float'
+    reveal_type(partial(Test.some, 1))  # N: Revealed type is "def (other: builtins.str) -> builtins.float"
 
 
 - case: partial_staticmethod
@@ -119,7 +119,7 @@
         def some(arg: int, other: str) -> float:
             ...
 
-    reveal_type(partial(Test.some, 1))  # N: Revealed type is 'def (other: builtins.str) -> builtins.float'
+    reveal_type(partial(Test.some, 1))  # N: Revealed type is "def (other: builtins.str) -> builtins.float"
 
 
 - case: partial_union
@@ -141,8 +141,8 @@
     # This does not work as well:
     reveal_type(partial(x, 1))
   out: |
-    main:13: note: Revealed type is 'Union[main.Inst, main.Other]'
-    main:15: note: Revealed type is 'def (*Any, **Any)'
+    main:13: note: Revealed type is "Union[main.Inst, main.Other]"
+    main:15: note: Revealed type is "def (*Any, **Any)"
 
 
 - case: partial_type_var
@@ -159,7 +159,7 @@
     def test(func: C) -> C:
         # One can say, that this case is not supported,
         # but I don't know how to work with it
-        reveal_type(partial(func, 1))  # N: Revealed type is 'def (*Any, **Any) -> <nothing>'
+        reveal_type(partial(func, 1))  # N: Revealed type is "def (*Any, **Any) -> <nothing>"
         return func
 
     test(first)
@@ -179,8 +179,8 @@
 
     def receives_type(a: int, t: Type[I]) -> I:
         x = partial(t, a)
-        reveal_type(x)  # N: Revealed type is 'def () -> I`-1'
-        reveal_type(x().arg)  # N: Revealed type is 'builtins.int'
+        reveal_type(x)  # N: Revealed type is "def () -> I`-1"
+        reveal_type(x().arg)  # N: Revealed type is "builtins.int"
         return t(1)
 
 
@@ -192,7 +192,7 @@
     def multiple(a: int, b: int) -> int:
         ...
 
-    reveal_type(partial(multiple, *(1, 2)))  # N: Revealed type is 'def (*Any, **Any) -> builtins.int*'
+    reveal_type(partial(multiple, *(1, 2)))  # N: Revealed type is "def (*Any, **Any) -> builtins.int*"
 
 
 - case: partial_star2_arg
@@ -203,7 +203,7 @@
     def multiple(a: int, b: int) -> int:
         ...
 
-    reveal_type(partial(multiple, **{'a': 1, 'b': 2}))  # N: Revealed type is 'def (*Any, **Any) -> builtins.int*'
+    reveal_type(partial(multiple, **{'a': 1, 'b': 2}))  # N: Revealed type is "def (*Any, **Any) -> builtins.int*"
 
 
 - case: partial_lambda
@@ -211,4 +211,4 @@
   main: |
     from returns.curry import partial
 
-    reveal_type(partial((lambda x, y: str(x + y)), 1))  # N: Revealed type is 'def (Any) -> builtins.str'
+    reveal_type(partial((lambda x, y: str(x + y)), 1))  # N: Revealed type is "def (Any) -> builtins.str"

--- a/typesafety/test_curry/test_partial/test_partial_generic.yml
+++ b/typesafety/test_curry/test_partial/test_partial_generic.yml
@@ -18,7 +18,7 @@
     reveal_type(partial(multiple, x)(y))
   out: |
     main:15: error: Argument 1 to "multiple" has incompatible type "List[str]"; expected "List[int]"
-    main:15: note: Revealed type is 'builtins.int*'
+    main:15: note: Revealed type is "builtins.int*"
 
 
 - case: partial_correct_generic
@@ -40,7 +40,7 @@
 
     reveal_type(partial(multiple, x)(y))
   out: |
-    main:15: note: Revealed type is 'builtins.int*'
+    main:15: note: Revealed type is "builtins.int*"
 
 
 - case: partial_single_generic
@@ -69,14 +69,14 @@
     reveal_type(partial(multiple, 2, x, True))
     reveal_type(partial(multiple, 2, x)())
   out: |
-    main:15: note: Revealed type is 'def [T] (a: builtins.int, b: builtins.list[T`-1], c: builtins.bool =) -> T`-1'
-    main:16: note: Revealed type is 'def [T] (b: builtins.list[T`-1], c: builtins.bool =) -> T`-1'
-    main:17: note: Revealed type is 'builtins.int*'
-    main:18: note: Revealed type is 'builtins.int*'
-    main:19: note: Revealed type is 'builtins.int*'
-    main:20: note: Revealed type is 'def (c: builtins.bool =) -> builtins.int*'
-    main:21: note: Revealed type is 'def () -> builtins.int*'
-    main:22: note: Revealed type is 'builtins.int*'
+    main:15: note: Revealed type is "def [T] (a: builtins.int, b: builtins.list[T`-1], c: builtins.bool =) -> T`-1"
+    main:16: note: Revealed type is "def [T] (b: builtins.list[T`-1], c: builtins.bool =) -> T`-1"
+    main:17: note: Revealed type is "builtins.int*"
+    main:18: note: Revealed type is "builtins.int*"
+    main:19: note: Revealed type is "builtins.int*"
+    main:20: note: Revealed type is "def (c: builtins.bool =) -> builtins.int*"
+    main:21: note: Revealed type is "def () -> builtins.int*"
+    main:22: note: Revealed type is "builtins.int*"
 
 
 - case: partial_double_generic_complex37
@@ -107,12 +107,12 @@
     reveal_type(partial(multiple, 1, b=y))
     reveal_type(partial(multiple, 1, c=y))
   out: |
-    main:18: note: Revealed type is 'def [B, A] (a: builtins.int, *, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]'
-    main:19: note: Revealed type is 'def [A, B] (*, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]'
-    main:20: note: Revealed type is 'def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.int*]'
-    main:21: note: Revealed type is 'def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.int*, B`-1]'
-    main:22: note: Revealed type is 'def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.str*]'
-    main:23: note: Revealed type is 'def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.str*, B`-1]'
+    main:18: note: Revealed type is "def [B, A] (a: builtins.int, *, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]"
+    main:19: note: Revealed type is "def [A, B] (*, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]"
+    main:20: note: Revealed type is "def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.int*]"
+    main:21: note: Revealed type is "def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.int*, B`-1]"
+    main:22: note: Revealed type is "def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.str*]"
+    main:23: note: Revealed type is "def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.str*, B`-1]"
 
 
 # Python3.8+ sorts generic arguments differently:
@@ -144,12 +144,12 @@
     reveal_type(partial(multiple, 1, b=y))
     reveal_type(partial(multiple, 1, c=y))
   out: |
-    main:18: note: Revealed type is 'def [B, A] (a: builtins.int, *, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]'
-    main:19: note: Revealed type is 'def [B, A] (*, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]'
-    main:20: note: Revealed type is 'def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.int*]'
-    main:21: note: Revealed type is 'def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.int*, B`-1]'
-    main:22: note: Revealed type is 'def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.str*]'
-    main:23: note: Revealed type is 'def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.str*, B`-1]'
+    main:18: note: Revealed type is "def [B, A] (a: builtins.int, *, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]"
+    main:19: note: Revealed type is "def [B, A] (*, b: builtins.list[B`-1], c: builtins.list[A`-2]) -> Union[A`-2, B`-1]"
+    main:20: note: Revealed type is "def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.int*]"
+    main:21: note: Revealed type is "def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.int*, B`-1]"
+    main:22: note: Revealed type is "def [A] (*, c: builtins.list[A`-2]) -> Union[A`-2, builtins.str*]"
+    main:23: note: Revealed type is "def [B] (*, b: builtins.list[B`-1]) -> Union[builtins.str*, B`-1]"
 
 
 - case: partial_double_generic
@@ -176,6 +176,6 @@
     reveal_type(partial(multiple, 1, b=x)(c=y))
     reveal_type(partial(multiple, 1, c=x)(b=y))
   out: |
-    main:17: note: Revealed type is 'def () -> Union[builtins.str*, builtins.int*]'
-    main:19: note: Revealed type is 'Union[builtins.str*, builtins.int]'
-    main:20: note: Revealed type is 'Union[builtins.int, builtins.str*]'
+    main:17: note: Revealed type is "def () -> Union[builtins.str*, builtins.int*]"
+    main:19: note: Revealed type is "Union[builtins.str*, builtins.int]"
+    main:20: note: Revealed type is "Union[builtins.int, builtins.str*]"

--- a/typesafety/test_curry/test_partial/test_partial_overload.yml
+++ b/typesafety/test_curry/test_partial/test_partial_overload.yml
@@ -21,7 +21,7 @@
     main:15: note:     def two_args(a, a: int) -> int
     main:15: note:     def two_args(a, a: str) -> str
     main:15: note: Possible overload variants:
-    main:15: note: Revealed type is 'def (*Any, **Any) -> builtins.int*'
+    main:15: note: Revealed type is "def (*Any, **Any) -> builtins.int*"
 
 
 - case: partial_wrong_overload2
@@ -47,7 +47,7 @@
     main:15: note:     def two_args(a, b: int) -> int
     main:15: note:     def two_args(a, b: str) -> str
     main:15: note: Possible overload variants:
-    main:15: note: Revealed type is 'Any'
+    main:15: note: Revealed type is "Any"
 
 
 - case: partial_regular_overload
@@ -77,11 +77,11 @@
     reveal_type(partial(two_args, 1, 'a'))
     reveal_type(partial(two_args, 'a'))
   out: |
-    main:19: note: Revealed type is 'Overload(def (a: builtins.int, b: builtins.int) -> builtins.int, def (a: builtins.int, b: builtins.str) -> builtins.str, def (a: builtins.str, b: builtins.str) -> builtins.str)'
-    main:20: note: Revealed type is 'Overload(def (b: builtins.int) -> builtins.int, def (b: builtins.str) -> builtins.str)'
-    main:21: note: Revealed type is 'def () -> builtins.int'
-    main:22: note: Revealed type is 'def () -> builtins.str'
-    main:23: note: Revealed type is 'def (b: builtins.str) -> builtins.str'
+    main:19: note: Revealed type is "Overload(def (a: builtins.int, b: builtins.int) -> builtins.int, def (a: builtins.int, b: builtins.str) -> builtins.str, def (a: builtins.str, b: builtins.str) -> builtins.str)"
+    main:20: note: Revealed type is "Overload(def (b: builtins.int) -> builtins.int, def (b: builtins.str) -> builtins.str)"
+    main:21: note: Revealed type is "def () -> builtins.int"
+    main:22: note: Revealed type is "def () -> builtins.str"
+    main:23: note: Revealed type is "def (b: builtins.str) -> builtins.str"
 
 
 - case: partial_generic_overload_kind1
@@ -117,12 +117,12 @@
     reveal_type(partial(two_args, x))
     reveal_type(partial(two_args, x, y))
   out: |
-    main:24: note: Revealed type is 'Overload(def [T] (a: builtins.int, b: builtins.list[T`-1]) -> T`-1, def [T] (a: builtins.int, b: builtins.set[T`-1]) -> T`-1, def [T] (a: builtins.list[T`-1], b: builtins.set[T`-1]) -> T`-1)'
-    main:25: note: Revealed type is 'Overload(def [T] (b: builtins.list[T`-1]) -> T`-1, def [T] (b: builtins.set[T`-1]) -> T`-1)'
-    main:26: note: Revealed type is 'def () -> builtins.float*'
-    main:27: note: Revealed type is 'def () -> builtins.float*'
-    main:28: note: Revealed type is 'def (b: builtins.set[builtins.float*]) -> builtins.float*'
-    main:29: note: Revealed type is 'def () -> builtins.float*'
+    main:24: note: Revealed type is "Overload(def [T] (a: builtins.int, b: builtins.list[T`-1]) -> T`-1, def [T] (a: builtins.int, b: builtins.set[T`-1]) -> T`-1, def [T] (a: builtins.list[T`-1], b: builtins.set[T`-1]) -> T`-1)"
+    main:25: note: Revealed type is "Overload(def [T] (b: builtins.list[T`-1]) -> T`-1, def [T] (b: builtins.set[T`-1]) -> T`-1)"
+    main:26: note: Revealed type is "def () -> builtins.float*"
+    main:27: note: Revealed type is "def () -> builtins.float*"
+    main:28: note: Revealed type is "def (b: builtins.set[builtins.float*]) -> builtins.float*"
+    main:29: note: Revealed type is "def () -> builtins.float*"
 
 
 - case: partial_generic_overload_kind2
@@ -161,11 +161,11 @@
     reveal_type(partial(two_args, a, b))
     reveal_type(partial(two_args, b, a))
   out: |
-    main:25: note: Revealed type is 'Overload(def [A] (a: builtins.int, b: builtins.list[A`-1]) -> A`-1, def [B] (a: builtins.int, b: builtins.list[B`-1]) -> B`-1, def [A, B] (a: builtins.list[A`-1], b: builtins.list[B`-2]) -> Union[A`-1, B`-2])'
-    main:26: note: Revealed type is 'Overload(def [A] (b: builtins.list[A`-1]) -> A`-1, def [B] (b: builtins.list[B`-1]) -> B`-1)'
-    main:27: note: Revealed type is 'Overload(def () -> builtins.float*, def () -> builtins.float*)'
-    main:28: note: Revealed type is 'Overload(def () -> builtins.str*, def () -> builtins.str*)'
-    main:29: note: Revealed type is 'def [B] (b: builtins.list[B`-2]) -> Union[builtins.float*, B`-2]'
-    main:30: note: Revealed type is 'def [B] (b: builtins.list[B`-2]) -> Union[builtins.str*, B`-2]'
-    main:31: note: Revealed type is 'def () -> Union[builtins.float*, builtins.str*]'
-    main:32: note: Revealed type is 'def () -> Union[builtins.str*, builtins.float*]'
+    main:25: note: Revealed type is "Overload(def [A] (a: builtins.int, b: builtins.list[A`-1]) -> A`-1, def [B] (a: builtins.int, b: builtins.list[B`-1]) -> B`-1, def [A, B] (a: builtins.list[A`-1], b: builtins.list[B`-2]) -> Union[A`-1, B`-2])"
+    main:26: note: Revealed type is "Overload(def [A] (b: builtins.list[A`-1]) -> A`-1, def [B] (b: builtins.list[B`-1]) -> B`-1)"
+    main:27: note: Revealed type is "Overload(def () -> builtins.float*, def () -> builtins.float*)"
+    main:28: note: Revealed type is "Overload(def () -> builtins.str*, def () -> builtins.str*)"
+    main:29: note: Revealed type is "def [B] (b: builtins.list[B`-2]) -> Union[builtins.float*, B`-2]"
+    main:30: note: Revealed type is "def [B] (b: builtins.list[B`-2]) -> Union[builtins.str*, B`-2]"
+    main:31: note: Revealed type is "def () -> Union[builtins.float*, builtins.str*]"
+    main:32: note: Revealed type is "def () -> Union[builtins.str*, builtins.float*]"

--- a/typesafety/test_examples/test_your_container/test_pair4_def.yml
+++ b/typesafety/test_examples/test_your_container/test_pair4_def.yml
@@ -14,4 +14,4 @@
     my_pair: Pair[int, str] = Pair.from_paired(1, 'a')
     reveal_type(my_pair.pair(function))
   out: |
-    main:8: note: Revealed type is 'test_pair4.Pair[builtins.float*, builtins.bool*]'
+    main:8: note: Revealed type is "test_pair4.Pair[builtins.float*, builtins.bool*]"

--- a/typesafety/test_examples/test_your_container/test_pair4_reuse.yml
+++ b/typesafety/test_examples/test_your_container/test_pair4_reuse.yml
@@ -12,5 +12,5 @@
     reveal_type(my_pair.map(str))
     reveal_type(map_(str)(my_pair))
   out: |
-    main:5: note: Revealed type is 'test_pair4.Pair[builtins.str*, builtins.int]'
-    main:6: note: Revealed type is 'test_pair4.Pair[builtins.str, builtins.int]'
+    main:5: note: Revealed type is "test_pair4.Pair[builtins.str*, builtins.int]"
+    main:6: note: Revealed type is "test_pair4.Pair[builtins.str, builtins.int]"

--- a/typesafety/test_functions/test_compose.yml
+++ b/typesafety/test_functions/test_compose.yml
@@ -9,7 +9,7 @@
     def second(num: float) -> str:
         return str(num)
 
-    reveal_type(compose(first, second))  # N: Revealed type is 'def (builtins.int*) -> builtins.str*'
+    reveal_type(compose(first, second))  # N: Revealed type is "def (builtins.int*) -> builtins.str*"
 
 
 - case: compose_two_wrong_functions
@@ -25,7 +25,7 @@
     reveal_type(compose(first, second))
   out: |
     main:9: error: Cannot infer type argument 2 of "compose"
-    main:9: note: Revealed type is 'def (Any) -> Any'
+    main:9: note: Revealed type is "def (Any) -> Any"
 
 
 - case: compose_optional_functions
@@ -40,4 +40,4 @@
     def second(num: float) -> str:
         return str(num)
 
-    reveal_type(compose(first, second))  # N: Revealed type is 'def (builtins.int*) -> builtins.str*'
+    reveal_type(compose(first, second))  # N: Revealed type is "def (builtins.int*) -> builtins.str*"

--- a/typesafety/test_functions/test_identity.yml
+++ b/typesafety/test_functions/test_identity.yml
@@ -3,4 +3,4 @@
   main: |
     from returns.functions import identity
 
-    reveal_type(identity(1))  # N: Revealed type is 'builtins.int*'
+    reveal_type(identity(1))  # N: Revealed type is "builtins.int*"

--- a/typesafety/test_functions/test_not_.yml
+++ b/typesafety/test_functions/test_not_.yml
@@ -6,7 +6,7 @@
     def is_even(number: int) -> bool:
         return number % 2 == 0
 
-    reveal_type(not_(is_even))  # N: Revealed type is 'def (number: builtins.int) -> builtins.bool'
+    reveal_type(not_(is_even))  # N: Revealed type is "def (number: builtins.int) -> builtins.bool"
 
 
 - case: function_with_two_arguments
@@ -17,4 +17,4 @@
     def number_is_in_list(number: int, list_: List[int]) -> bool:
         return number in list_
 
-    reveal_type(not_(number_is_in_list))  # N: Revealed type is 'def (number: builtins.int, list_: builtins.list[builtins.int]) -> builtins.bool'
+    reveal_type(not_(number_is_in_list))  # N: Revealed type is "def (number: builtins.int, list_: builtins.list[builtins.int]) -> builtins.bool"

--- a/typesafety/test_functions/test_raise_exception.yml
+++ b/typesafety/test_functions/test_raise_exception.yml
@@ -3,4 +3,4 @@
   main: |
     from returns.functions import raise_exception
 
-    reveal_type(raise_exception(ValueError()))  # N: Revealed type is '<nothing>'
+    reveal_type(raise_exception(ValueError()))  # N: Revealed type is "<nothing>"

--- a/typesafety/test_functions/test_tap.yml
+++ b/typesafety/test_functions/test_tap.yml
@@ -6,7 +6,7 @@
     def first(num: int) -> float:
         return float(num)
 
-    reveal_type(tap(first))  # N: Revealed type is 'def (builtins.int*) -> builtins.int*'
+    reveal_type(tap(first))  # N: Revealed type is "def (builtins.int*) -> builtins.int*"
 
 
 - case: untap_single_function
@@ -17,5 +17,5 @@
     def first(num: int) -> float:
         return float(num)
 
-    reveal_type(untap(first))  # N: Revealed type is 'def (builtins.int*)'
-    reveal_type(untap(first)(1))  # N: Revealed type is 'None'
+    reveal_type(untap(first))  # N: Revealed type is "def (builtins.int*)"
+    reveal_type(untap(first)(1))  # N: Revealed type is "None"

--- a/typesafety/test_future/test_future_container/test_asyncify_decorator.yml
+++ b/typesafety/test_future/test_future_container/test_asyncify_decorator.yml
@@ -10,4 +10,4 @@
     ) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> typing.Coroutine[Any, Any, builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> typing.Coroutine[Any, Any, builtins.int*]"

--- a/typesafety/test_future/test_future_container/test_future_base.yml
+++ b/typesafety/test_future/test_future_container/test_future_base.yml
@@ -6,8 +6,8 @@
     async def test() -> int:
         ...
 
-    reveal_type(Future(test()))  # N: Revealed type is 'returns.future.Future[builtins.int*]'
-    reveal_type(Future.from_value(1))  # N: Revealed type is 'returns.future.Future[builtins.int*]'
+    reveal_type(Future(test()))  # N: Revealed type is "returns.future.Future[builtins.int*]"
+    reveal_type(Future.from_value(1))  # N: Revealed type is "returns.future.Future[builtins.int*]"
 
 
 - case: future_awaitable
@@ -16,8 +16,8 @@
     from returns.future import Future
 
     async def main() -> None:
-        reveal_type(await Future.from_value(1))  # N: Revealed type is 'returns.io.IO[builtins.int*]'
-        reveal_type(await Future.from_value(1).awaitable())  # N: Revealed type is 'returns.io.IO*[builtins.int*]'
+        reveal_type(await Future.from_value(1))  # N: Revealed type is "returns.io.IO[builtins.int*]"
+        reveal_type(await Future.from_value(1).awaitable())  # N: Revealed type is "returns.io.IO*[builtins.int*]"
 
 
 - case: future_bind
@@ -28,7 +28,7 @@
     def bind_future(arg: int) -> Future[str]:
         ...
 
-    reveal_type(Future.from_value(1).bind(bind_future))  # N: Revealed type is 'returns.future.Future[builtins.str*]'
+    reveal_type(Future.from_value(1).bind(bind_future))  # N: Revealed type is "returns.future.Future[builtins.str*]"
 
 
 - case: future_bind_awaitable
@@ -39,7 +39,7 @@
     async def bind_awaitable(arg: int) -> str:
         ...
 
-    reveal_type(Future.from_value(1).bind_awaitable(bind_awaitable))  # N: Revealed type is 'returns.future.Future[builtins.str*]'
+    reveal_type(Future.from_value(1).bind_awaitable(bind_awaitable))  # N: Revealed type is "returns.future.Future[builtins.str*]"
 
 
 - case: future_bind_async
@@ -50,7 +50,7 @@
     async def bind_async(arg: int) -> Future[str]:
         ...
 
-    reveal_type(Future.from_value(1).bind_async(bind_async))  # N: Revealed type is 'returns.future.Future[builtins.str*]'
+    reveal_type(Future.from_value(1).bind_async(bind_async))  # N: Revealed type is "returns.future.Future[builtins.str*]"
 
 
 - case: future_map
@@ -58,7 +58,7 @@
   main: |
     from returns.future import Future
 
-    reveal_type(Future.from_value(1).map(str))  # N: Revealed type is 'returns.future.Future[builtins.str*]'
+    reveal_type(Future.from_value(1).map(str))  # N: Revealed type is "returns.future.Future[builtins.str*]"
 
 
 - case: future_apply
@@ -69,4 +69,4 @@
     def transform(arg: int) -> str:
         ...
 
-    reveal_type(Future.from_value(1).apply(Future.from_value(transform)))  # N: Revealed type is 'returns.future.Future[builtins.str*]'
+    reveal_type(Future.from_value(1).apply(Future.from_value(transform)))  # N: Revealed type is "returns.future.Future[builtins.str*]"

--- a/typesafety/test_future/test_future_container/test_future_decorator.yml
+++ b/typesafety/test_future/test_future_container/test_future_decorator.yml
@@ -10,7 +10,7 @@
     ) -> int:
         ...
 
-    reveal_type(test)  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.future.Future[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.future.Future[builtins.int*]"
 
 
 - case: future_composition
@@ -21,4 +21,4 @@
     async def test(first: int) -> str:
         ...
 
-    reveal_type(future(test))  # N: Revealed type is 'def (first: builtins.int) -> returns.future.Future[builtins.str*]'
+    reveal_type(future(test))  # N: Revealed type is "def (first: builtins.int) -> returns.future.Future[builtins.str*]"

--- a/typesafety/test_future/test_future_container/test_future_typecast.yml
+++ b/typesafety/test_future/test_future_container/test_future_typecast.yml
@@ -5,7 +5,7 @@
 
     first: Future[ValueError]
     second: Future[Exception] = first
-    reveal_type(second)  # N: Revealed type is 'returns.future.Future[builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.future.Future[builtins.Exception]"
 
 
 - case: future_from_value
@@ -13,7 +13,7 @@
   main: |
     from returns.future import Future
 
-    reveal_type(Future.from_value(1))  # N: Revealed type is 'returns.future.Future[builtins.int*]'
+    reveal_type(Future.from_value(1))  # N: Revealed type is "returns.future.Future[builtins.int*]"
 
 
 - case: future_from_io
@@ -22,7 +22,7 @@
     from returns.future import Future
     from returns.io import IO
 
-    reveal_type(Future.from_io(IO(1)))  # N: Revealed type is 'returns.future.Future[builtins.int*]'
+    reveal_type(Future.from_io(IO(1)))  # N: Revealed type is "returns.future.Future[builtins.int*]"
 
 
 - case: future_from_downcast
@@ -31,4 +31,4 @@
     from returns.future import Future, FutureResult
 
     first: FutureResult[int, ValueError]
-    reveal_type(Future.from_future_result(first))  # N: Revealed type is 'returns.future.Future[returns.result.Result[builtins.int*, builtins.ValueError*]]'
+    reveal_type(Future.from_future_result(first))  # N: Revealed type is "returns.future.Future[returns.result.Result[builtins.int*, builtins.ValueError*]]"

--- a/typesafety/test_future/test_future_result_container/test_future_result_base.yml
+++ b/typesafety/test_future/test_future_result_container/test_future_result_base.yml
@@ -4,10 +4,10 @@
     from returns.future import FutureResult
 
     async def main() -> None:
-        reveal_type(await FutureResult.from_value(1))  # N: Revealed type is 'returns.io.IOResult[builtins.int*, Any]'
-        reveal_type(await FutureResult.from_value(1).awaitable())  # N: Revealed type is 'returns.io.IOResult*[builtins.int*, Any]'
-        reveal_type(await FutureResult.from_failure(1))  # N: Revealed type is 'returns.io.IOResult[Any, builtins.int*]'
-        reveal_type(await FutureResult.from_failure(1).awaitable())  # N: Revealed type is 'returns.io.IOResult*[Any, builtins.int*]'
+        reveal_type(await FutureResult.from_value(1))  # N: Revealed type is "returns.io.IOResult[builtins.int*, Any]"
+        reveal_type(await FutureResult.from_value(1).awaitable())  # N: Revealed type is "returns.io.IOResult*[builtins.int*, Any]"
+        reveal_type(await FutureResult.from_failure(1))  # N: Revealed type is "returns.io.IOResult[Any, builtins.int*]"
+        reveal_type(await FutureResult.from_failure(1).awaitable())  # N: Revealed type is "returns.io.IOResult*[Any, builtins.int*]"
 
 
 - case: future_result_swap
@@ -16,7 +16,7 @@
     from returns.future import FutureResult
 
     x: FutureResult[int, str]
-    reveal_type(x.swap())  # N: Revealed type is 'returns.future.FutureResult[builtins.str*, builtins.int*]'
+    reveal_type(x.swap())  # N: Revealed type is "returns.future.FutureResult[builtins.str*, builtins.int*]"
 
 
 - case: future_result_bind
@@ -29,7 +29,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.bind(bind))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind(bind))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_bind_awaitable
@@ -42,7 +42,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.bind_awaitable(bind_awaitable))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind_awaitable(bind_awaitable))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_bind_async
@@ -55,7 +55,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.bind_async(bind_async))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind_async(bind_async))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_bind_result
@@ -69,7 +69,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.bind_result(bind))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind_result(bind))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_bind_ioresult
@@ -83,7 +83,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.bind_ioresult(bind))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind_ioresult(bind))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_bind_future
@@ -96,7 +96,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.bind_future(bind_future))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind_future(bind_future))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_bind_async_future
@@ -109,7 +109,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.bind_async_future(bind_future))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind_async_future(bind_future))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_map
@@ -119,7 +119,7 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.map(float))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.map(float))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_apply
@@ -131,7 +131,7 @@
     first: FutureResult[int, str]
     second: FutureResult[Callable[[int], float], str]
 
-    reveal_type(first.apply(second))  # N: Revealed type is 'returns.future.FutureResult[builtins.float*, builtins.str]'
+    reveal_type(first.apply(second))  # N: Revealed type is "returns.future.FutureResult[builtins.float*, builtins.str]"
 
 
 - case: future_result_alt
@@ -141,7 +141,7 @@
 
     first: FutureResult[int, int]
 
-    reveal_type(first.alt(float))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.float*]'
+    reveal_type(first.alt(float))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.float*]"
 
 
 - case: future_result_lash
@@ -154,4 +154,4 @@
 
     first: FutureResult[int, str]
 
-    reveal_type(first.lash(bind))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.float*]'
+    reveal_type(first.lash(bind))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.float*]"

--- a/typesafety/test_future/test_future_result_container/test_future_result_typecast.yml
+++ b/typesafety/test_future/test_future_result_container/test_future_result_typecast.yml
@@ -9,8 +9,8 @@
     test1: FutureResultE[int] = first
     test2: FutureResult[int, Exception] = second
 
-    reveal_type(first)  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.Exception]'
-    reveal_type(second)  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.Exception]"
+    reveal_type(second)  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.Exception]"
 
 
 - case: future_result_covariant_cast
@@ -20,7 +20,7 @@
 
     first: FutureResult[TypeError, ValueError]  # we cast both values
     second: FutureResult[Exception, Exception] = first
-    reveal_type(second)  # N: Revealed type is 'returns.future.FutureResult[builtins.Exception, builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.future.FutureResult[builtins.Exception, builtins.Exception]"
 
 
 - case: future_result_from_typecast
@@ -31,7 +31,7 @@
 
     first: Result[int, str]
 
-    reveal_type(FutureResult.from_typecast(Future.from_value(first)))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, builtins.str*]'
+    reveal_type(FutureResult.from_typecast(Future.from_value(first)))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, builtins.str*]"
 
 
 - case: future_result_constructor
@@ -43,9 +43,9 @@
     async def test() -> Result[int, str]:
         ...
 
-    reveal_type(FutureResult(test()))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, builtins.str*]'
-    reveal_type(FutureResult.from_value(1))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, Any]'
-    reveal_type(FutureResult.from_failure(1))  # N: Revealed type is 'returns.future.FutureResult[Any, builtins.int*]'
+    reveal_type(FutureResult(test()))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, builtins.str*]"
+    reveal_type(FutureResult.from_value(1))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, Any]"
+    reveal_type(FutureResult.from_failure(1))  # N: Revealed type is "returns.future.FutureResult[Any, builtins.int*]"
 
 
 - case: future_result_unit_functions
@@ -53,8 +53,8 @@
   main: |
     from returns.future import FutureSuccess, FutureFailure
 
-    reveal_type(FutureSuccess(1))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, Any]'
-    reveal_type(FutureFailure(1))  # N: Revealed type is 'returns.future.FutureResult[Any, builtins.int*]'
+    reveal_type(FutureSuccess(1))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, Any]"
+    reveal_type(FutureFailure(1))  # N: Revealed type is "returns.future.FutureResult[Any, builtins.int*]"
 
 
 - case: future_result_from_result
@@ -63,8 +63,8 @@
     from returns.future import FutureResult
     from returns.result import Result, Success, Failure
 
-    reveal_type(FutureResult.from_result(Success(1)))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, Any]'
-    reveal_type(FutureResult.from_result(Failure(1)))  # N: Revealed type is 'returns.future.FutureResult[Any, builtins.int*]'
+    reveal_type(FutureResult.from_result(Success(1)))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, Any]"
+    reveal_type(FutureResult.from_result(Failure(1)))  # N: Revealed type is "returns.future.FutureResult[Any, builtins.int*]"
 
 
 - case: future_result_from_io
@@ -73,10 +73,10 @@
     from returns.future import FutureResult
     from returns.io import IO, IOSuccess, IOFailure
 
-    reveal_type(FutureResult.from_ioresult(IOSuccess(1)))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, Any]'
-    reveal_type(FutureResult.from_ioresult(IOFailure(1)))  # N: Revealed type is 'returns.future.FutureResult[Any, builtins.int*]'
-    reveal_type(FutureResult.from_io(IO(1)))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, Any]'
-    reveal_type(FutureResult.from_failed_io(IO(1)))  # N: Revealed type is 'returns.future.FutureResult[Any, builtins.int*]'
+    reveal_type(FutureResult.from_ioresult(IOSuccess(1)))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, Any]"
+    reveal_type(FutureResult.from_ioresult(IOFailure(1)))  # N: Revealed type is "returns.future.FutureResult[Any, builtins.int*]"
+    reveal_type(FutureResult.from_io(IO(1)))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, Any]"
+    reveal_type(FutureResult.from_failed_io(IO(1)))  # N: Revealed type is "returns.future.FutureResult[Any, builtins.int*]"
 
 
 - case: future_result_from_future
@@ -84,5 +84,5 @@
   main: |
     from returns.future import Future, FutureResult
 
-    reveal_type(FutureResult.from_future(Future.from_value(1)))  # N: Revealed type is 'returns.future.FutureResult[builtins.int*, Any]'
-    reveal_type(FutureResult.from_failed_future(Future.from_value(1)))  # N: Revealed type is 'returns.future.FutureResult[Any, builtins.int*]'
+    reveal_type(FutureResult.from_future(Future.from_value(1)))  # N: Revealed type is "returns.future.FutureResult[builtins.int*, Any]"
+    reveal_type(FutureResult.from_failed_future(Future.from_value(1)))  # N: Revealed type is "returns.future.FutureResult[Any, builtins.int*]"

--- a/typesafety/test_future/test_future_result_container/test_future_safe_decorator.yml
+++ b/typesafety/test_future/test_future_result_container/test_future_safe_decorator.yml
@@ -10,7 +10,7 @@
     ) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.future.FutureResult[builtins.int, builtins.Exception]'
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.future.FutureResult[builtins.int, builtins.Exception]"
 
 
 - case: future_safe_composition_with_args
@@ -24,4 +24,4 @@
     ) -> int:
         return 1
 
-    reveal_type(future_safe(test))  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.future.FutureResult[builtins.int, builtins.Exception]'
+    reveal_type(future_safe(test))  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.future.FutureResult[builtins.int, builtins.Exception]"

--- a/typesafety/test_interfaces/test_altable/test_inheritance.yml
+++ b/typesafety/test_interfaces/test_altable/test_inheritance.yml
@@ -23,7 +23,7 @@
     def test(arg: str) -> int:
         ...
 
-    reveal_type(MyClass(1, '1').alt(test))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.int*]'
+    reveal_type(MyClass(1, '1').alt(test))  # N: Revealed type is "main.MyClass[builtins.int, builtins.int*]"
 
 
 - case: altable_inheritance_correct3
@@ -53,7 +53,7 @@
     def test(arg: str) -> float:
         ...
 
-    reveal_type(MyClass(1, 'a', True).alt(test))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.float*, builtins.bool]'
+    reveal_type(MyClass(1, 'a', True).alt(test))  # N: Revealed type is "main.MyClass[builtins.int, builtins.float*, builtins.bool]"
 
 
 - case: altable_inheritance_missing
@@ -71,7 +71,7 @@
 
     MyClass()
   out: |
-    main:11: error: Cannot instantiate abstract class 'MyClass' with abstract attribute 'alt'
+    main:11: error: Cannot instantiate abstract class "MyClass" with abstract attribute "alt"
 
 
 - case: altable_inheritance_wrong2

--- a/typesafety/test_interfaces/test_bindable/test_inheritance.yml
+++ b/typesafety/test_interfaces/test_bindable/test_inheritance.yml
@@ -21,7 +21,7 @@
     def test(arg: str) -> MyClass[int]:
         ...
 
-    reveal_type(MyClass('1').bind(test))  # N: Revealed type is 'main.MyClass[builtins.int*]'
+    reveal_type(MyClass('1').bind(test))  # N: Revealed type is "main.MyClass[builtins.int*]"
 
 
 - case: bindable_inheritance_correct2
@@ -49,7 +49,7 @@
     def test(arg: str) -> MyClass[int, str]:
         ...
 
-    reveal_type(MyClass('1', 'a').bind(test))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.str]'
+    reveal_type(MyClass('1', 'a').bind(test))  # N: Revealed type is "main.MyClass[builtins.int*, builtins.str]"
 
 
 - case: bindable_inheritance_correct3
@@ -79,7 +79,7 @@
     def test(arg: str) -> MyClass[int, str, bool]:
         ...
 
-    reveal_type(MyClass('1', 'a', True).bind(test))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.str, builtins.bool]'
+    reveal_type(MyClass('1', 'a', True).bind(test))  # N: Revealed type is "main.MyClass[builtins.int*, builtins.str, builtins.bool]"
 
 
 - case: bindable_inheritance_missing
@@ -96,7 +96,7 @@
 
     MyClass()
   out: |
-    main:10: error: Cannot instantiate abstract class 'MyClass' with abstract attribute 'bind'
+    main:10: error: Cannot instantiate abstract class "MyClass" with abstract attribute "bind"
 
 
 - case: bindable_inheritance_wrong1

--- a/typesafety/test_interfaces/test_container/test_inheritance.yml
+++ b/typesafety/test_interfaces/test_container/test_inheritance.yml
@@ -12,4 +12,4 @@
 
     MyClass()
   out: |
-    main:10: error: Cannot instantiate abstract class 'MyClass' with abstract attributes 'apply', 'bind', 'from_value' and 'map'
+    main:10: error: Cannot instantiate abstract class "MyClass" with abstract attributes "apply", "bind", "from_value" and "map"

--- a/typesafety/test_interfaces/test_equality/test_inheritance.yml
+++ b/typesafety/test_interfaces/test_equality/test_inheritance.yml
@@ -17,8 +17,8 @@
 
         equals = container_equality
 
-    reveal_type(MyOwn(1).equals(MyOwn(1)))  # N: Revealed type is 'builtins.bool'
-    reveal_type(MyOwn(1).equals(MyOwn('a')))  # N: Revealed type is 'builtins.bool'
+    reveal_type(MyOwn(1).equals(MyOwn(1)))  # N: Revealed type is "builtins.bool"
+    reveal_type(MyOwn(1).equals(MyOwn('a')))  # N: Revealed type is "builtins.bool"
     MyOwn(1).equals(1)  # E: Argument 1 has incompatible type "int"; expected "KindN[MyOwn[Any], Any, Any, Any]"
 
 
@@ -42,8 +42,8 @@
         def equals(self, other: MyOwn[V]) -> bool:
             ...
 
-    reveal_type(MyOwn(1).equals(MyOwn(1)))  # N: Revealed type is 'builtins.bool'
-    reveal_type(MyOwn(1).equals(MyOwn('a')))  # N: Revealed type is 'builtins.bool'
+    reveal_type(MyOwn(1).equals(MyOwn(1)))  # N: Revealed type is "builtins.bool"
+    reveal_type(MyOwn(1).equals(MyOwn('a')))  # N: Revealed type is "builtins.bool"
 
 
 - case: equable_inheritance_missing

--- a/typesafety/test_interfaces/test_failable/test_diverse_failable.yml
+++ b/typesafety/test_interfaces/test_failable/test_diverse_failable.yml
@@ -21,7 +21,7 @@
             ...
 
     x: MyClass[str, int]
-    reveal_type(MyClass.from_failure(10))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.int*]'
+    reveal_type(MyClass.from_failure(10))  # N: Revealed type is "main.MyClass[builtins.int*, builtins.int*]"
 
 
 - case: diverse_failable_inheritance_correct3
@@ -48,7 +48,7 @@
             ...
 
     x: MyClass[float, bool, str]
-    reveal_type(MyClass.from_failure(10))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.int*, <nothing>]'
+    reveal_type(MyClass.from_failure(10))  # N: Revealed type is "main.MyClass[builtins.int*, builtins.int*, <nothing>]"
 
 
 - case: diverse_failable_inheritance_missing

--- a/typesafety/test_interfaces/test_lashable/test_inheritance.yml
+++ b/typesafety/test_interfaces/test_lashable/test_inheritance.yml
@@ -23,7 +23,7 @@
     def test(arg: str) -> MyClass[int, int]:
         ...
 
-    reveal_type(MyClass(1, '1').lash(test))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.int*]'
+    reveal_type(MyClass(1, '1').lash(test))  # N: Revealed type is "main.MyClass[builtins.int, builtins.int*]"
 
 
 - case: lashable_inheritance_correct3
@@ -53,7 +53,7 @@
     def test(arg: str) -> MyClass[int, float, bool]:
         ...
 
-    reveal_type(MyClass(1, 'a', True).lash(test))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.float*, builtins.bool]'
+    reveal_type(MyClass(1, 'a', True).lash(test))  # N: Revealed type is "main.MyClass[builtins.int, builtins.float*, builtins.bool]"
 
 
 - case: lashable_inheritance_missing
@@ -71,7 +71,7 @@
 
     MyClass()
   out: |
-    main:11: error: Cannot instantiate abstract class 'MyClass' with abstract attribute 'lash'
+    main:11: error: Cannot instantiate abstract class "MyClass" with abstract attribute "lash"
 
 
 - case: lashable_inheritance_wrong2

--- a/typesafety/test_interfaces/test_mappable/test_inheritance.yml
+++ b/typesafety/test_interfaces/test_mappable/test_inheritance.yml
@@ -15,7 +15,7 @@
         def map(self, function: Callable[[V], N]) -> 'MyClass[N]':
             return MyClass(function(self.value))
 
-    reveal_type(MyClass('1').map(int))  # N: Revealed type is 'main.MyClass[builtins.int*]'
+    reveal_type(MyClass('1').map(int))  # N: Revealed type is "main.MyClass[builtins.int*]"
 
 
 - case: mappable_inheritance_correct2
@@ -37,7 +37,7 @@
         def map(self, function: Callable[[V], N]) -> 'MyClass[N, E]':
             return MyClass(function(self.value), self.error)
 
-    reveal_type(MyClass('1', 1).map(int))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.int]'
+    reveal_type(MyClass('1', 1).map(int))  # N: Revealed type is "main.MyClass[builtins.int*, builtins.int]"
 
 
 - case: mappable_inheritance_correct3
@@ -61,7 +61,7 @@
         def map(self, function: Callable[[V], N]) -> 'MyClass[N, E, K]':
             return MyClass(function(self.value), self.error, self.last)
 
-    reveal_type(MyClass('1', 1, True).map(int))  # N: Revealed type is 'main.MyClass[builtins.int*, builtins.int, builtins.bool]'
+    reveal_type(MyClass('1', 1, True).map(int))  # N: Revealed type is "main.MyClass[builtins.int*, builtins.int, builtins.bool]"
 
 
 - case: mappable_inheritance_missing
@@ -78,7 +78,7 @@
 
     MyClass()
   out: |
-    main:10: error: Cannot instantiate abstract class 'MyClass' with abstract attribute 'map'
+    main:10: error: Cannot instantiate abstract class "MyClass" with abstract attribute "map"
 
 
 - case: mappable_inheritance_wrong1

--- a/typesafety/test_interfaces/test_specific/test_future/test_futurebased_inheritance.yml
+++ b/typesafety/test_interfaces/test_specific/test_future/test_futurebased_inheritance.yml
@@ -55,7 +55,7 @@
         ...
 
     x: Future[int]
-    reveal_type(MyClass.from_future(x).bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is 'main.MyClass[builtins.str*]'
+    reveal_type(MyClass.from_future(x).bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is "main.MyClass[builtins.str*]"
 
 
 - case: future_inheritance_correct2
@@ -116,7 +116,7 @@
         ...
 
     x: MyClass[int, bool]
-    reveal_type(x.bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is 'main.MyClass[builtins.str*, builtins.bool]'
+    reveal_type(x.bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is "main.MyClass[builtins.str*, builtins.bool]"
 
 
 - case: future_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_future/test_futurelike_inheritance.yml
+++ b/typesafety/test_interfaces/test_specific/test_future/test_futurelike_inheritance.yml
@@ -55,7 +55,7 @@
         ...
 
     x: Future[int]
-    reveal_type(MyClass.from_future(x).bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is 'main.MyClass[builtins.str*]'
+    reveal_type(MyClass.from_future(x).bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is "main.MyClass[builtins.str*]"
 
 
 - case: future_inheritance_correct2
@@ -116,7 +116,7 @@
         ...
 
     x: MyClass[int, bool]
-    reveal_type(x.bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is 'main.MyClass[builtins.str*, builtins.bool]'
+    reveal_type(x.bind_future(test1).bind_async_future(test2).bind_async(test3))  # N: Revealed type is "main.MyClass[builtins.str*, builtins.bool]"
 
 
 - case: future_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_future_result/test_future_result_based.yml
+++ b/typesafety/test_interfaces/test_specific/test_future_result/test_future_result_based.yml
@@ -48,7 +48,7 @@
         ...
 
     x: MyClass[int, str]
-    reveal_type(x.bind_future_result(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(x.bind_future_result(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: future_result_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_future_result/test_future_result_like.yml
+++ b/typesafety/test_interfaces/test_specific/test_future_result/test_future_result_like.yml
@@ -41,7 +41,7 @@
         ...
 
     x: MyClass[int, str]
-    reveal_type(x.bind_future_result(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(x.bind_future_result(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: future_result_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_io/test_io_like.yml
+++ b/typesafety/test_interfaces/test_specific/test_io/test_io_like.yml
@@ -29,7 +29,7 @@
         ...
 
     x: IO[int]
-    reveal_type(MyClass.from_io(x).bind_io(test))  # N: Revealed type is 'main.MyClass[builtins.float*]'
+    reveal_type(MyClass.from_io(x).bind_io(test))  # N: Revealed type is "main.MyClass[builtins.float*]"
 
 
 - case: io_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_ioresult/test_ioresultbased_inheritance.yml
+++ b/typesafety/test_interfaces/test_specific/test_ioresult/test_ioresultbased_inheritance.yml
@@ -48,7 +48,7 @@
         ...
 
     x: IOResult[int, str]
-    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: ioresult_inheritance_correct3
@@ -102,7 +102,7 @@
         ...
 
     x: IOResult[int, str]
-    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str, Any]'
+    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str, Any]"
 
 
 - case: ioresult_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_ioresult/test_ioresultlike_inheritance.yml
+++ b/typesafety/test_interfaces/test_specific/test_ioresult/test_ioresultlike_inheritance.yml
@@ -42,7 +42,7 @@
         ...
 
     x: IOResult[int, str]
-    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: ioresult_inheritance_correct3
@@ -90,7 +90,7 @@
         ...
 
     x: IOResult[int, str]
-    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str, Any]'
+    reveal_type(MyClass.from_ioresult(x).bind_ioresult(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str, Any]"
 
 
 - case: ioresult_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_reader/test_reader_based2.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader/test_reader_based2.yml
@@ -49,7 +49,7 @@
         ...
 
     x: Reader[int, str]
-    reveal_type(MyClass.from_context(x).bind_context(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(MyClass.from_context(x).bind_context(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: reader_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_reader/test_reader_like2.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader/test_reader_like2.yml
@@ -46,7 +46,7 @@
         ...
 
     x: Reader[int, str]
-    reveal_type(MyClass.from_context(x).bind_context(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(MyClass.from_context(x).bind_context(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: reader_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_reader/test_reader_like3.yml
+++ b/typesafety/test_interfaces/test_specific/test_reader/test_reader_like3.yml
@@ -50,7 +50,7 @@
         ...
 
     x: Reader[int, str]
-    reveal_type(MyClass.from_context(x).bind_context(test))  # N: Revealed type is 'main.MyClass[builtins.float*, Any, builtins.str]'
+    reveal_type(MyClass.from_context(x).bind_context(test))  # N: Revealed type is "main.MyClass[builtins.float*, Any, builtins.str]"
 
 
 - case: reader_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_result/test_resultbased_inheritance.yml
+++ b/typesafety/test_interfaces/test_specific/test_result/test_resultbased_inheritance.yml
@@ -51,7 +51,7 @@
         ...
 
     x: Result[int, str]
-    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: result_inheritance_correct3
@@ -108,7 +108,7 @@
         ...
 
     x: Result[int, str]
-    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str, Any]'
+    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str, Any]"
 
 
 - case: result_inheritance_missing

--- a/typesafety/test_interfaces/test_specific/test_result/test_resultlike_inheritance.yml
+++ b/typesafety/test_interfaces/test_specific/test_result/test_resultlike_inheritance.yml
@@ -36,7 +36,7 @@
         ...
 
     x: Result[int, str]
-    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str]'
+    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str]"
 
 
 - case: result_inheritance_correct3
@@ -78,7 +78,7 @@
         ...
 
     x: Result[int, str]
-    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is 'main.MyClass[builtins.float*, builtins.str, Any]'
+    reveal_type(MyClass.from_result(x).bind_result(test))  # N: Revealed type is "main.MyClass[builtins.float*, builtins.str, Any]"
 
 
 - case: result_inheritance_missing

--- a/typesafety/test_interfaces/test_unwrappable/test_inheritance.yml
+++ b/typesafety/test_interfaces/test_unwrappable/test_inheritance.yml
@@ -22,8 +22,8 @@
             ...
 
     x = MyOwn(1, 'a')
-    reveal_type(x.unwrap())  # N: Revealed type is 'builtins.int*'
-    reveal_type(x.failure())  # N: Revealed type is 'builtins.str*'
+    reveal_type(x.unwrap())  # N: Revealed type is "builtins.int*"
+    reveal_type(x.failure())  # N: Revealed type is "builtins.str*"
 
 
 - case: unwrappable_missing_inheritance
@@ -42,7 +42,7 @@
     ):
       ...
 
-    MyOwn()  # E: Cannot instantiate abstract class 'MyOwn' with abstract attributes 'failure' and 'unwrap'
+    MyOwn()  # E: Cannot instantiate abstract class "MyOwn" with abstract attributes "failure" and "unwrap"
 
 
 - case: unwrappable_wrong_inheritance

--- a/typesafety/test_io/test_io_container/test_impure.yml
+++ b/typesafety/test_io/test_io_container/test_impure.yml
@@ -7,7 +7,7 @@
     def test() -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def () -> returns.io.IO[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def () -> returns.io.IO[builtins.int*]"
 
 
 - case: impure_composition_no_params
@@ -18,7 +18,7 @@
     def test() -> int:
         return 1
 
-    reveal_type(impure(test))  # N: Revealed type is 'def () -> returns.io.IO[builtins.int*]'
+    reveal_type(impure(test))  # N: Revealed type is "def () -> returns.io.IO[builtins.int*]"
 
 
 - case: impure_decorator_with_args
@@ -31,7 +31,7 @@
     def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.io.IO[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.io.IO[builtins.int*]"
 
 
 - case: impure_composition_with_args
@@ -43,7 +43,7 @@
     def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         return 1
 
-    reveal_type(impure(test))  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.io.IO[builtins.int*]'
+    reveal_type(impure(test))  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.io.IO[builtins.int*]"
 
 
 - case: impure_decorator_with_args_kwargs
@@ -55,7 +55,7 @@
     def test(*args, **kwargs) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (*args: Any, **kwargs: Any) -> returns.io.IO[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> returns.io.IO[builtins.int*]"
 
 
 - case: impure_decorator_with_typed_args_kwargs
@@ -67,4 +67,4 @@
     def test(*args: int, **kwargs: str) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (*args: builtins.int, **kwargs: builtins.str) -> returns.io.IO[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (*args: builtins.int, **kwargs: builtins.str) -> returns.io.IO[builtins.int*]"

--- a/typesafety/test_io/test_io_container/test_io_base.yml
+++ b/typesafety/test_io/test_io_container/test_io_base.yml
@@ -3,7 +3,7 @@
   main: |
     from returns.io import IO
 
-    reveal_type(IO(1))  # N: Revealed type is 'returns.io.IO[builtins.int*]'
+    reveal_type(IO(1))  # N: Revealed type is "returns.io.IO[builtins.int*]"
 
 
 - case: io_constructor2
@@ -11,7 +11,7 @@
   main: |
     from returns.io import IO
 
-    reveal_type(IO.from_value(1))  # N: Revealed type is 'returns.io.IO[builtins.int*]'
+    reveal_type(IO.from_value(1))  # N: Revealed type is "returns.io.IO[builtins.int*]"
 
 
 - case: io_constructor3
@@ -19,7 +19,7 @@
   main: |
     from returns.io import IO
 
-    reveal_type(IO.from_io(IO(1)))  # N: Revealed type is 'returns.io.IO[builtins.int*]'
+    reveal_type(IO.from_io(IO(1)))  # N: Revealed type is "returns.io.IO[builtins.int*]"
 
 
 - case: io_bind
@@ -30,7 +30,7 @@
     def bind_io(input_io: int) -> IO[str]:
         ...
 
-    reveal_type(IO(1).bind(bind_io))  # N: Revealed type is 'returns.io.IO[builtins.str*]'
+    reveal_type(IO(1).bind(bind_io))  # N: Revealed type is "returns.io.IO[builtins.str*]"
 
 
 
@@ -42,7 +42,7 @@
     def bind_io(input_io: int) -> IO[str]:
         ...
 
-    reveal_type(IO(1).bind_io(bind_io))  # N: Revealed type is 'returns.io.IO[builtins.str*]'
+    reveal_type(IO(1).bind_io(bind_io))  # N: Revealed type is "returns.io.IO[builtins.str*]"
 
 
 - case: io_map
@@ -50,7 +50,7 @@
   main: |
     from returns.io import IO
 
-    reveal_type(IO(1).map(str))  # N: Revealed type is 'returns.io.IO[builtins.str*]'
+    reveal_type(IO(1).map(str))  # N: Revealed type is "returns.io.IO[builtins.str*]"
 
 
 - case: io_apply
@@ -61,4 +61,4 @@
     def transform(arg: int) -> str:
         ...
 
-    reveal_type(IO(1).apply(IO(transform)))  # N: Revealed type is 'returns.io.IO[builtins.str*]'
+    reveal_type(IO(1).apply(IO(transform)))  # N: Revealed type is "returns.io.IO[builtins.str*]"

--- a/typesafety/test_io/test_io_container/test_io_type_cast.yml
+++ b/typesafety/test_io/test_io_container/test_io_type_cast.yml
@@ -5,7 +5,7 @@
 
     first: IO[ValueError]
     second: IO[Exception] = first
-    reveal_type(second)  # N: Revealed type is 'returns.io.IO[builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.io.IO[builtins.Exception]"
 
 
 - case: io_from_ioresult
@@ -15,7 +15,7 @@
 
     x: IOResult[int, str]
 
-    reveal_type(IO.from_ioresult(x))  # N: Revealed type is 'returns.io.IO[returns.result.Result[builtins.int*, builtins.str*]]'
+    reveal_type(IO.from_ioresult(x))  # N: Revealed type is "returns.io.IO[returns.result.Result[builtins.int*, builtins.str*]]"
 
 
 - case: io_getattr

--- a/typesafety/test_io/test_ioresult_container/test_construct_iofailure.yml
+++ b/typesafety/test_io/test_ioresult_container/test_construct_iofailure.yml
@@ -7,7 +7,7 @@
         ...
 
     first: IOResult[str, int] = IOFailure(1)
-    reveal_type(first.lash(returns_result))  # N: Revealed type is 'returns.io.IOResult[builtins.str, builtins.Exception*]'
+    reveal_type(first.lash(returns_result))  # N: Revealed type is "returns.io.IOResult[builtins.str, builtins.Exception*]"
 
 
 - case: iofailure_alt
@@ -15,7 +15,7 @@
   main: |
     from returns.io import IOFailure
 
-    reveal_type(IOFailure(1).alt(str))  # N: Revealed type is 'returns.io.IOResult[Any, builtins.str*]'
+    reveal_type(IOFailure(1).alt(str))  # N: Revealed type is "returns.io.IOResult[Any, builtins.str*]"
 
 
 - case: iofailure_iofailure
@@ -23,4 +23,4 @@
   main: |
     from returns.io import IOFailure
 
-    reveal_type(IOFailure(1).failure())  # N: Revealed type is 'returns.io.IO[builtins.int*]'
+    reveal_type(IOFailure(1).failure())  # N: Revealed type is "returns.io.IO[builtins.int*]"

--- a/typesafety/test_io/test_ioresult_container/test_construct_iosucess.yml
+++ b/typesafety/test_io/test_ioresult_container/test_construct_iosucess.yml
@@ -7,7 +7,7 @@
         ...
 
     first: IOResult[int, Exception] = IOSuccess(1)
-    reveal_type(first.bind(returns_result))  # N: Revealed type is 'returns.io.IOResult[builtins.str*, builtins.Exception]'
+    reveal_type(first.bind(returns_result))  # N: Revealed type is "returns.io.IOResult[builtins.str*, builtins.Exception]"
 
 
 - case: iosuccess_bind_result
@@ -20,7 +20,7 @@
         ...
 
     first: IOResult[int, Exception] = IOSuccess(1)
-    reveal_type(first.bind_result(returns_result))  # N: Revealed type is 'returns.io.IOResult[builtins.str*, builtins.Exception]'
+    reveal_type(first.bind_result(returns_result))  # N: Revealed type is "returns.io.IOResult[builtins.str*, builtins.Exception]"
 
 
 - case: iosuccess_bind_io
@@ -32,7 +32,7 @@
         ...
 
     first: IOResult[int, Exception] = IOSuccess(1)
-    reveal_type(first.bind_io(returns_io))  # N: Revealed type is 'returns.io.IOResult[builtins.str*, builtins.Exception]'
+    reveal_type(first.bind_io(returns_io))  # N: Revealed type is "returns.io.IOResult[builtins.str*, builtins.Exception]"
 
 
 - case: iosuccess_map
@@ -40,7 +40,7 @@
   main: |
     from returns.io import IOSuccess, IOResult
 
-    reveal_type(IOSuccess(1).map(str))  # N: Revealed type is 'returns.io.IOResult[builtins.str*, Any]'
+    reveal_type(IOSuccess(1).map(str))  # N: Revealed type is "returns.io.IOResult[builtins.str*, Any]"
 
 
 - case: iosuccess_apply
@@ -51,7 +51,7 @@
     def transform(arg: int) -> str:
         ...
 
-    reveal_type(IOSuccess(1).apply(IOSuccess(transform)))  # N: Revealed type is 'returns.io.IOResult[builtins.str*, Any]'
+    reveal_type(IOSuccess(1).apply(IOSuccess(transform)))  # N: Revealed type is "returns.io.IOResult[builtins.str*, Any]"
 
 
 - case: iosuccess_value_or
@@ -59,7 +59,7 @@
   main: |
     from returns.io import IOSuccess
 
-    reveal_type(IOSuccess(1).value_or(None))  # N: Revealed type is 'returns.io.IO[Union[builtins.int, None]]'
+    reveal_type(IOSuccess(1).value_or(None))  # N: Revealed type is "returns.io.IO[Union[builtins.int, None]]"
 
 
 - case: iosuccess_unwrap
@@ -67,4 +67,4 @@
   main: |
     from returns.io import IOSuccess
 
-    reveal_type(IOSuccess(1).unwrap())  # N: Revealed type is 'returns.io.IO[builtins.int*]'
+    reveal_type(IOSuccess(1).unwrap())  # N: Revealed type is "returns.io.IO[builtins.int*]"

--- a/typesafety/test_io/test_ioresult_container/test_impure_safe.yml
+++ b/typesafety/test_io/test_ioresult_container/test_impure_safe.yml
@@ -7,4 +7,4 @@
     def test(arg: str) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (arg: builtins.str) -> returns.io.IOResult[builtins.int, builtins.Exception]'
+    reveal_type(test)  # N: Revealed type is "def (arg: builtins.str) -> returns.io.IOResult[builtins.int, builtins.Exception]"

--- a/typesafety/test_io/test_ioresult_container/test_ioresult_helpers.yml
+++ b/typesafety/test_io/test_ioresult_container/test_ioresult_helpers.yml
@@ -6,7 +6,7 @@
 
     container: IO[Result[int, str]]
 
-    reveal_type(IOResult.from_typecast(container))  # N: Revealed type is 'returns.io.IOResult[builtins.int*, builtins.str*]'
+    reveal_type(IOResult.from_typecast(container))  # N: Revealed type is "returns.io.IOResult[builtins.int*, builtins.str*]"
 
 
 - case: ioresult_from_io
@@ -16,7 +16,7 @@
 
     container: IO[str]
 
-    reveal_type(IOResult.from_io(container))  # N: Revealed type is 'returns.io.IOResult[builtins.str*, Any]'
+    reveal_type(IOResult.from_io(container))  # N: Revealed type is "returns.io.IOResult[builtins.str*, Any]"
 
 
 - case: ioresult_from_failed_io
@@ -26,7 +26,7 @@
 
     container: IO[str]
 
-    reveal_type(IOResult.from_failed_io(container))  # N: Revealed type is 'returns.io.IOResult[Any, builtins.str*]'
+    reveal_type(IOResult.from_failed_io(container))  # N: Revealed type is "returns.io.IOResult[Any, builtins.str*]"
 
 
 - case: ioresult_success_type
@@ -34,7 +34,7 @@
   main: |
     from returns.io import IOResult
 
-    reveal_type(IOResult.success_type)  # N: Revealed type is 'Type[returns.io._IOSuccess]'
+    reveal_type(IOResult.success_type)  # N: Revealed type is "Type[returns.io._IOSuccess]"
 
 
 - case: ioresult_failure_type
@@ -42,4 +42,4 @@
   main: |
     from returns.io import IOResult
 
-    reveal_type(IOResult.failure_type)  # N: Revealed type is 'Type[returns.io._IOFailure]'
+    reveal_type(IOResult.failure_type)  # N: Revealed type is "Type[returns.io._IOFailure]"

--- a/typesafety/test_io/test_ioresult_container/test_ioresult_typecast.yml
+++ b/typesafety/test_io/test_ioresult_container/test_ioresult_typecast.yml
@@ -4,7 +4,7 @@
     from returns.io import IOResult, IOSuccess
 
     first: IOResult[int, Exception] = IOSuccess(1)
-    reveal_type(first)  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.Exception]"
 
 
 - case: ioresult_failure_cast1
@@ -13,7 +13,7 @@
     from returns.io import IOResult, IOFailure
 
     first: IOResult[int, Exception] = IOFailure(Exception())
-    reveal_type(first)  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.Exception]"
 
 
 - case: ioresult_failure_cast2
@@ -22,7 +22,7 @@
     from returns.io import IOResult, IOFailure
 
     first: IOResult[int, Exception] = IOFailure(TypeError())
-    reveal_type(first)  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.Exception]"
 
 
 - case: ioresult_swap
@@ -31,7 +31,7 @@
     from returns.io import IOResult
 
     x: IOResult[int, str]
-    reveal_type(x.swap())  # N: Revealed type is 'returns.io.IOResult[builtins.str*, builtins.int*]'
+    reveal_type(x.swap())  # N: Revealed type is "returns.io.IOResult[builtins.str*, builtins.int*]"
 
 
 - case: ioresult_getattr
@@ -48,7 +48,7 @@
   main: |
     from returns.io import IOResult
 
-    reveal_type(IOResult.from_value(1))  # N: Revealed type is 'returns.io.IOResult[builtins.int*, Any]'
+    reveal_type(IOResult.from_value(1))  # N: Revealed type is "returns.io.IOResult[builtins.int*, Any]"
 
 
 - case: ioresult_from_failure
@@ -56,7 +56,7 @@
   main: |
     from returns.io import IOResult
 
-    reveal_type(IOResult.from_failure(1))  # N: Revealed type is 'returns.io.IOResult[Any, builtins.int*]'
+    reveal_type(IOResult.from_failure(1))  # N: Revealed type is "returns.io.IOResult[Any, builtins.int*]"
 
 
 - case: ioresult_covariant_cast
@@ -66,7 +66,7 @@
 
     first: IOResult[TypeError, ValueError]  # we cast both values
     second: IOResult[Exception, Exception] = first
-    reveal_type(second)  # N: Revealed type is 'returns.io.IOResult[builtins.Exception, builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.io.IOResult[builtins.Exception, builtins.Exception]"
 
 
 - case: ioresult_success_bind_contra1
@@ -78,7 +78,7 @@
       ...
 
     first: IOResult[int, str] = IOSuccess(4)
-    reveal_type(first.bind(test))  # N: Revealed type is 'returns.io.IOResult[builtins.float*, builtins.str]'
+    reveal_type(first.bind(test))  # N: Revealed type is "returns.io.IOResult[builtins.float*, builtins.str]"
 
 
 - case: ioresult_success_bind_contra2
@@ -91,7 +91,7 @@
 
     first: IOResult[int, Exception]
     second = first.bind(test)
-    reveal_type(second)  # N: Revealed type is 'returns.io.IOResult[builtins.int*, builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.io.IOResult[builtins.int*, builtins.Exception]"
 
 
 - case: ioresult_correct_usage
@@ -104,7 +104,7 @@
             return IOSuccess(inner_value * 2)
         return IOFailure(str(inner_value))
 
-    reveal_type(factory(1))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(factory(1))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: ioresulte_typecast1
@@ -118,7 +118,7 @@
         return IOFailure(ValueError(arg))
 
     result: IOResult[int, Exception] = function(1)
-    reveal_type(result)  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.Exception]'
+    reveal_type(result)  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.Exception]"
 
 
 - case: ioresulte_typecast2
@@ -132,4 +132,4 @@
         return IOFailure(ValueError(arg))
 
     result: IOResultE[int] = function(1)
-    reveal_type(result)  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.Exception]'
+    reveal_type(result)  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.Exception]"

--- a/typesafety/test_iterables/test_fold/test_fold_collect.yml
+++ b/typesafety/test_iterables/test_fold/test_fold_collect.yml
@@ -15,13 +15,13 @@
 
     acc: Result[Tuple[()], str]
 
-    reveal_type(Fold.collect(x1, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect(x2, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect(x3, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect(x4, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect(x5, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect(x6, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect(x7, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
+    reveal_type(Fold.collect(x1, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect(x2, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect(x3, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect(x4, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect(x5, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect(x6, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect(x7, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
 
 
 - case: fold_collect_io
@@ -33,7 +33,7 @@
 
     acc = IO(())
     x: Iterable[IO[float]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.io.IO[builtins.tuple[builtins.float]]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.io.IO[builtins.tuple[builtins.float]]"
 
 
 - case: fold_collect_maybe
@@ -45,7 +45,7 @@
 
     acc = Maybe.from_value(())
     x: Iterable[Maybe[float]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.maybe.Maybe[builtins.tuple[builtins.float]]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.maybe.Maybe[builtins.tuple[builtins.float]]"
 
 
 - case: fold_collect_result
@@ -57,7 +57,7 @@
 
     acc: Result[Tuple[()], str]
     x: Iterable[Result[float, str]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.float], builtins.str]"
 
 
 - case: fold_collect_ioresult
@@ -69,7 +69,7 @@
 
     acc: IOResult[Tuple[()], str]
     x: Iterable[IOResult[float, str]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.io.IOResult[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.io.IOResult[builtins.tuple[builtins.float], builtins.str]"
 
 
 - case: fold_collect_requires_context
@@ -81,7 +81,7 @@
 
     acc: RequiresContext[Tuple[()], str]
     x: Iterable[RequiresContext[float, str]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.tuple[builtins.float], builtins.str]"
 
 
 - case: fold_collect_requires_context_result
@@ -93,7 +93,7 @@
 
     acc: RequiresContextResult[Tuple[()], str, bool]
     x: Iterable[RequiresContextResult[float, str, bool]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]"
 
 
 - case: fold_collect_requires_context_ioresult
@@ -105,7 +105,7 @@
 
     acc: RequiresContextIOResult[Tuple[()], str, bool]
     x: Iterable[RequiresContextIOResult[float, str, bool]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]"
 
 
 - case: fold_collect_requires_context_future_result
@@ -117,7 +117,7 @@
 
     acc: RequiresContextFutureResult[Tuple[()], str, bool]
     x: Iterable[RequiresContextFutureResult[float, str, bool]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]"
 
 
 - case: fold_collect_future
@@ -129,7 +129,7 @@
 
     acc: Future[Tuple[()]]
     x: Iterable[Future[float]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.future.Future[builtins.tuple[builtins.float]]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.future.Future[builtins.tuple[builtins.float]]"
 
 
 - case: fold_collect_future_result
@@ -141,7 +141,7 @@
 
     acc: FutureResult[Tuple[()], str]
     x: Iterable[FutureResult[float, str]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'returns.future.FutureResult[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "returns.future.FutureResult[builtins.tuple[builtins.float], builtins.str]"
 
 
 - case: fold_collect_custom_type
@@ -159,4 +159,4 @@
 
     acc: MyClass[Tuple[()]]
     x: Iterable[MyClass[float]]
-    reveal_type(Fold.collect(x, acc))  # N: Revealed type is 'main.MyClass[builtins.tuple[builtins.float]]'
+    reveal_type(Fold.collect(x, acc))  # N: Revealed type is "main.MyClass[builtins.tuple[builtins.float]]"

--- a/typesafety/test_iterables/test_fold/test_fold_collect_all.yml
+++ b/typesafety/test_iterables/test_fold/test_fold_collect_all.yml
@@ -15,13 +15,13 @@
 
     acc: Result[Tuple[()], str]
 
-    reveal_type(Fold.collect_all(x1, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect_all(x2, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect_all(x3, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect_all(x4, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect_all(x5, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect_all(x6, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
-    reveal_type(Fold.collect_all(x7, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.int], builtins.str]'
+    reveal_type(Fold.collect_all(x1, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect_all(x2, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect_all(x3, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect_all(x4, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect_all(x5, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect_all(x6, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
+    reveal_type(Fold.collect_all(x7, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.int], builtins.str]"
 
 
 - case: fold_collect_all_wrong_type
@@ -45,7 +45,7 @@
 
     acc = Maybe.from_value(())
     x: Iterable[Maybe[float]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'returns.maybe.Maybe[builtins.tuple[builtins.float]]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "returns.maybe.Maybe[builtins.tuple[builtins.float]]"
 
 
 - case: fold_collect_all_result
@@ -57,7 +57,7 @@
 
     acc: Result[Tuple[()], str]
     x: Iterable[Result[float, str]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'returns.result.Result[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "returns.result.Result[builtins.tuple[builtins.float], builtins.str]"
 
 
 - case: fold_collect_all_ioresult
@@ -69,7 +69,7 @@
 
     acc: IOResult[Tuple[()], str]
     x: Iterable[IOResult[float, str]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'returns.io.IOResult[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "returns.io.IOResult[builtins.tuple[builtins.float], builtins.str]"
 
 
 - case: fold_collect_all_requires_context_result
@@ -81,7 +81,7 @@
 
     acc: RequiresContextResult[Tuple[()], str, bool]
     x: Iterable[RequiresContextResult[float, str, bool]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]"
 
 
 - case: fold_collect_all_requires_context_ioresult
@@ -93,7 +93,7 @@
 
     acc: RequiresContextIOResult[Tuple[()], str, bool]
     x: Iterable[RequiresContextIOResult[float, str, bool]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]"
 
 
 - case: fold_collect_all_requires_context_future_result
@@ -105,7 +105,7 @@
 
     acc: RequiresContextFutureResult[Tuple[()], str, bool]
     x: Iterable[RequiresContextFutureResult[float, str, bool]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.tuple[builtins.float], builtins.str, builtins.bool]"
 
 
 - case: fold_collect_all_future_result
@@ -117,7 +117,7 @@
 
     acc: FutureResult[Tuple[()], str]
     x: Iterable[FutureResult[float, str]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'returns.future.FutureResult[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "returns.future.FutureResult[builtins.tuple[builtins.float], builtins.str]"
 
 
 - case: fold_collect_all_custom_type
@@ -136,4 +136,4 @@
 
     acc: MyClass[Tuple[()], str]
     x: Iterable[MyClass[float, str]]
-    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is 'main.MyClass[builtins.tuple[builtins.float], builtins.str]'
+    reveal_type(Fold.collect_all(x, acc))  # N: Revealed type is "main.MyClass[builtins.tuple[builtins.float], builtins.str]"

--- a/typesafety/test_iterables/test_fold/test_fold_loop.yml
+++ b/typesafety/test_iterables/test_fold/test_fold_loop.yml
@@ -20,13 +20,13 @@
     def div(first: int) -> Callable[[float], float]:
         return lambda second: first / second
 
-    reveal_type(Fold.loop(x1, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
-    reveal_type(Fold.loop(x2, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
-    reveal_type(Fold.loop(x3, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
-    reveal_type(Fold.loop(x4, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
-    reveal_type(Fold.loop(x5, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
-    reveal_type(Fold.loop(x6, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
-    reveal_type(Fold.loop(x7, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
+    reveal_type(Fold.loop(x1, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
+    reveal_type(Fold.loop(x2, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
+    reveal_type(Fold.loop(x3, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
+    reveal_type(Fold.loop(x4, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
+    reveal_type(Fold.loop(x5, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
+    reveal_type(Fold.loop(x6, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
+    reveal_type(Fold.loop(x7, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
 
 
 - case: fold_loop_io
@@ -41,7 +41,7 @@
 
     acc: IO[float]
     x: Iterable[IO[int]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.io.IO[builtins.float]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.io.IO[builtins.float]"
 
 
 - case: fold_loop_maybe
@@ -56,7 +56,7 @@
 
     acc: Maybe[float]
     x: Iterable[Maybe[int]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.maybe.Maybe[builtins.float]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.maybe.Maybe[builtins.float]"
 
 
 - case: fold_loop_result
@@ -71,7 +71,7 @@
 
     acc: Result[float, str]
     x: Iterable[Result[int, str]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.result.Result[builtins.float, builtins.str]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.result.Result[builtins.float, builtins.str]"
 
 
 - case: fold_loop_ioresult
@@ -86,7 +86,7 @@
 
     acc: IOResult[float, str]
     x: Iterable[IOResult[int, str]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.io.IOResult[builtins.float, builtins.str]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.io.IOResult[builtins.float, builtins.str]"
 
 
 - case: fold_loop_requires_context
@@ -101,7 +101,7 @@
 
     acc: RequiresContext[float, str]
     x: Iterable[RequiresContext[int, str]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.float, builtins.str]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.float, builtins.str]"
 
 
 - case: fold_loop_requires_context_result
@@ -116,7 +116,7 @@
 
     acc: RequiresContextResult[float, str, bool]
     x: Iterable[RequiresContextResult[int, str, bool]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.str, builtins.bool]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.str, builtins.bool]"
 
 
 - case: fold_loop_requires_context_ioresult
@@ -131,7 +131,7 @@
 
     acc: RequiresContextIOResult[float, str, bool]
     x: Iterable[RequiresContextIOResult[int, str, bool]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.str, builtins.bool]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.str, builtins.bool]"
 
 
 - case: fold_loop_requires_context_future_result
@@ -146,7 +146,7 @@
 
     acc: RequiresContextFutureResult[float, str, bool]
     x: Iterable[RequiresContextFutureResult[int, str, bool]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.str, builtins.bool]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.str, builtins.bool]"
 
 
 - case: fold_loop_future
@@ -161,7 +161,7 @@
 
     acc: Future[float]
     x: Iterable[Future[int]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.future.Future[builtins.float]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.future.Future[builtins.float]"
 
 
 - case: fold_loop_future_result
@@ -176,7 +176,7 @@
 
     acc: FutureResult[float, str]
     x: Iterable[FutureResult[int, str]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'returns.future.FutureResult[builtins.float, builtins.str]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "returns.future.FutureResult[builtins.float, builtins.str]"
 
 
 - case: fold_loop_custom_type
@@ -197,4 +197,4 @@
 
     acc: MyClass[float]
     x: Iterable[MyClass[int]]
-    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is 'main.MyClass[builtins.float]'
+    reveal_type(Fold.loop(x, acc, div))  # N: Revealed type is "main.MyClass[builtins.float]"

--- a/typesafety/test_maybe/test_maybe_decorator.yml
+++ b/typesafety/test_maybe/test_maybe_decorator.yml
@@ -7,7 +7,7 @@
     def test() -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def () -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def () -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_decorator_no_params_optional
@@ -20,7 +20,7 @@
     def test() -> Optional[int]:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def () -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def () -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_composition_no_params
@@ -31,7 +31,7 @@
     def test() -> int:
         return 1
 
-    reveal_type(maybe(test))  # N: Revealed type is 'def () -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(maybe(test))  # N: Revealed type is "def () -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_decorator_with_args
@@ -44,7 +44,7 @@
     def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_composition_with_args
@@ -56,7 +56,7 @@
     def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         return 1
 
-    reveal_type(maybe(test))  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(maybe(test))  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_decorator_with_args_kwargs
@@ -68,7 +68,7 @@
     def test(*args, **kwargs) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (*args: Any, **kwargs: Any) -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_decorator_with_typed_args_kwargs
@@ -80,7 +80,7 @@
     def test(*args: int, **kwargs: str) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (*args: builtins.int, **kwargs: builtins.str) -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def (*args: builtins.int, **kwargs: builtins.str) -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_decorator_with_optional
@@ -93,7 +93,7 @@
     def test() -> Optional[int]:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def () -> returns.maybe.Maybe[builtins.int*]'
+    reveal_type(test)  # N: Revealed type is "def () -> returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_multiple_decorators
@@ -108,4 +108,4 @@
     def test() -> Optional[int]:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def () -> returns.io.IO[returns.maybe.Maybe*[builtins.int*]]'
+    reveal_type(test)  # N: Revealed type is "def () -> returns.io.IO[returns.maybe.Maybe*[builtins.int*]]"

--- a/typesafety/test_maybe/test_maybe_type.yml
+++ b/typesafety/test_maybe/test_maybe_type.yml
@@ -4,7 +4,7 @@
     from returns.maybe import Maybe
 
     value: int
-    reveal_type(Maybe.from_value(value))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int*]'
+    reveal_type(Maybe.from_value(value))  # N: Revealed type is "returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_from_value2
@@ -14,7 +14,7 @@
     from returns.maybe import Maybe
 
     value: Optional[int]
-    reveal_type(Maybe.from_value(value))  # N: Revealed type is 'returns.maybe.Maybe[Union[builtins.int, None]]'
+    reveal_type(Maybe.from_value(value))  # N: Revealed type is "returns.maybe.Maybe[Union[builtins.int, None]]"
 
 
 - case: maybe_from_optional1
@@ -24,7 +24,7 @@
     from returns.maybe import Maybe
 
     value: int
-    reveal_type(Maybe.from_optional(value))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int*]'
+    reveal_type(Maybe.from_optional(value))  # N: Revealed type is "returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_from_optional2
@@ -34,7 +34,7 @@
     from returns.maybe import Maybe
 
     value: Optional[int]
-    reveal_type(Maybe.from_optional(value))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int*]'
+    reveal_type(Maybe.from_optional(value))  # N: Revealed type is "returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_map_regular
@@ -43,7 +43,7 @@
     from returns.maybe import Maybe
 
     result = Maybe.from_value(1).map(lambda i: i / i)
-    reveal_type(result)  # N: Revealed type is 'returns.maybe.Maybe[builtins.float*]'
+    reveal_type(result)  # N: Revealed type is "returns.maybe.Maybe[builtins.float*]"
 
 
 - case: maybe_map_optional1
@@ -52,7 +52,7 @@
     from returns.maybe import Maybe
 
     result = Maybe.from_value({'a': 'b'}).map(lambda d: d.get('a', None))
-    reveal_type(result)  # N: Revealed type is 'returns.maybe.Maybe[Union[builtins.str, None]]'
+    reveal_type(result)  # N: Revealed type is "returns.maybe.Maybe[Union[builtins.str, None]]"
 
 
 - case: maybe_map_optional2
@@ -61,7 +61,7 @@
     from returns.maybe import Maybe
 
     result = Maybe.from_value(1).bind(lambda d: Maybe.from_value(str(d)))
-    reveal_type(result)  # N: Revealed type is 'returns.maybe.Maybe[builtins.str*]'
+    reveal_type(result)  # N: Revealed type is "returns.maybe.Maybe[builtins.str*]"
 
 
 - case: maybe_apply
@@ -70,7 +70,7 @@
     from returns.maybe import Maybe
 
     result = Maybe.from_value(1).apply(Maybe.from_value(float))
-    reveal_type(result)  # N: Revealed type is 'returns.maybe.Maybe[builtins.float*]'
+    reveal_type(result)  # N: Revealed type is "returns.maybe.Maybe[builtins.float*]"
 
 
 - case: maybe_bind1
@@ -81,7 +81,7 @@
     def test(arg: int) -> Maybe[str]:
         ...
 
-    reveal_type(Maybe.from_value(1).bind(test))  # N: Revealed type is 'returns.maybe.Maybe[builtins.str*]'
+    reveal_type(Maybe.from_value(1).bind(test))  # N: Revealed type is "returns.maybe.Maybe[builtins.str*]"
 
 
 - case: maybe_bind2
@@ -93,7 +93,7 @@
     def test(arg: int) -> Maybe[Optional[str]]:
         ...
 
-    reveal_type(Maybe.from_value(1).bind(test))  # N: Revealed type is 'returns.maybe.Maybe[Union[builtins.str, None]]'
+    reveal_type(Maybe.from_value(1).bind(test))  # N: Revealed type is "returns.maybe.Maybe[Union[builtins.str, None]]"
 
 
 - case: maybe_bind_optional
@@ -105,7 +105,7 @@
     def test(arg: int) -> Optional[str]:
         ...
 
-    reveal_type(Maybe.from_value(1).bind_optional(test))  # N: Revealed type is 'returns.maybe.Maybe[builtins.str*]'
+    reveal_type(Maybe.from_value(1).bind_optional(test))  # N: Revealed type is "returns.maybe.Maybe[builtins.str*]"
 
 
 - case: maybe_value_or
@@ -114,7 +114,7 @@
     from returns.maybe import Maybe
 
     result = Maybe.from_value(1).value_or(None)
-    reveal_type(result)  # N: Revealed type is 'Union[builtins.int, None]'
+    reveal_type(result)  # N: Revealed type is "Union[builtins.int, None]"
 
 
 - case: maybe_or_else1
@@ -123,7 +123,7 @@
     from returns.maybe import Maybe
 
     result = Maybe.from_value(1).or_else_call(lambda: 2)
-    reveal_type(result)  # N: Revealed type is 'builtins.int'
+    reveal_type(result)  # N: Revealed type is "builtins.int"
 
 
 - case: maybe_or_else2
@@ -135,7 +135,7 @@
         ...
 
     result = Maybe.from_value(1).or_else_call(fallback)
-    reveal_type(result)  # N: Revealed type is 'Union[builtins.int, builtins.str*]'
+    reveal_type(result)  # N: Revealed type is "Union[builtins.int, builtins.str*]"
 
 
 - case: maybe_or_else3
@@ -148,7 +148,7 @@
         ...
 
     result = Maybe.from_value(1).or_else_call(fallback)
-    reveal_type(result)  # N: Revealed type is 'builtins.int'
+    reveal_type(result)  # N: Revealed type is "builtins.int"
 
 
 - case: maybe_unwrap
@@ -156,4 +156,4 @@
   main: |
     from returns.maybe import Some
 
-    reveal_type(Some(1).unwrap())  # N: Revealed type is 'builtins.int*'
+    reveal_type(Some(1).unwrap())  # N: Revealed type is "builtins.int*"

--- a/typesafety/test_maybe/test_maybe_type_cast.yml
+++ b/typesafety/test_maybe/test_maybe_type_cast.yml
@@ -5,7 +5,7 @@
 
     first: Maybe[ValueError]
     second: Maybe[Exception] = first
-    reveal_type(second)  # N: Revealed type is 'returns.maybe.Maybe[builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.maybe.Maybe[builtins.Exception]"
 
 
 - case: maybe_getattr
@@ -22,7 +22,7 @@
   main: |
     from returns.maybe import Some
 
-    reveal_type(Some(1))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int*]'
+    reveal_type(Some(1))  # N: Revealed type is "returns.maybe.Maybe[builtins.int*]"
 
 
 - case: maybe_nothing_const
@@ -30,7 +30,7 @@
   main: |
     from returns.maybe import Nothing
 
-    reveal_type(Nothing)  # N: Revealed type is 'returns.maybe.Maybe[<nothing>]'
+    reveal_type(Nothing)  # N: Revealed type is "returns.maybe.Maybe[<nothing>]"
 
 
 - case: maybe_result_success_type
@@ -38,7 +38,7 @@
   main: |
     from returns.maybe import Maybe
 
-    reveal_type(Maybe.success_type)  # N: Revealed type is 'Type[returns.maybe._Some[Any]]'
+    reveal_type(Maybe.success_type)  # N: Revealed type is "Type[returns.maybe._Some[Any]]"
 
 
 - case: maybe_result_failure_type
@@ -46,5 +46,5 @@
   main: |
     from returns.maybe import Maybe
 
-    reveal_type(Maybe.failure_type)  # N: Revealed type is 'Type[returns.maybe._Nothing]'
+    reveal_type(Maybe.failure_type)  # N: Revealed type is "Type[returns.maybe._Nothing]"
 

--- a/typesafety/test_methods/test_cond.yml
+++ b/typesafety/test_methods/test_cond.yml
@@ -4,7 +4,7 @@
     from returns.methods import cond
     from returns.result import Result
 
-    reveal_type(cond(Result, True, 42, '42'))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(cond(Result, True, 42, '42'))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: cond_ioresult
@@ -13,7 +13,7 @@
     from returns.io import IOResult
     from returns.methods import cond
 
-    reveal_type(cond(IOResult, False, 'success', 'failure'))  # N: Revealed type is 'returns.io.IOResult[builtins.str, builtins.str]'
+    reveal_type(cond(IOResult, False, 'success', 'failure'))  # N: Revealed type is "returns.io.IOResult[builtins.str, builtins.str]"
 
 
 - case: cond_future_result
@@ -22,7 +22,7 @@
     from returns.future import FutureResult
     from returns.methods import cond
 
-    reveal_type(cond(FutureResult, False, True, False))  # N: Revealed type is 'returns.future.FutureResult[builtins.bool, builtins.bool]'
+    reveal_type(cond(FutureResult, False, True, False))  # N: Revealed type is "returns.future.FutureResult[builtins.bool, builtins.bool]"
 
 
 - case: cond_reader_result
@@ -31,7 +31,7 @@
     from returns.methods import cond
     from returns.context import ReaderResult
 
-    reveal_type(cond(ReaderResult, True, 1.0, False))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.bool, Any]'
+    reveal_type(cond(ReaderResult, True, 1.0, False))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.bool, Any]"
 
 
 - case: cond_reader_ioresult
@@ -40,7 +40,7 @@
     from returns.methods import cond
     from returns.context import ReaderIOResult
 
-    reveal_type(cond(ReaderIOResult, True, 1.0, False))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bool, Any]'
+    reveal_type(cond(ReaderIOResult, True, 1.0, False))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bool, Any]"
 
 
 - case: cond_reader_future_result
@@ -49,7 +49,7 @@
     from returns.methods import cond
     from returns.context import ReaderFutureResult
 
-    reveal_type(cond(ReaderFutureResult, True, 1, 1.0))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.float, Any]'
+    reveal_type(cond(ReaderFutureResult, True, 1, 1.0))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.float, Any]"
 
 
 - case: cond_maybe
@@ -58,7 +58,7 @@
     from returns.methods import cond
     from returns.maybe import Maybe
 
-    reveal_type(cond(Maybe, True, 'test'))  # N: Revealed type is 'returns.maybe.Maybe[builtins.str]'
+    reveal_type(cond(Maybe, True, 'test'))  # N: Revealed type is "returns.maybe.Maybe[builtins.str]"
 
 
 - case: cond_custom_type
@@ -82,4 +82,4 @@
     reveal_type(cond(MyOwn, True, 'test', 1.0))
   out: |
     main:16: error: Only concrete class can be given where "Type[MyOwn[Any, Any]]" is expected
-    main:16: note: Revealed type is 'main.MyOwn[builtins.str, builtins.float]'
+    main:16: note: Revealed type is "main.MyOwn[builtins.str, builtins.float]"

--- a/typesafety/test_methods/test_unwrap_or_failure.yml
+++ b/typesafety/test_methods/test_unwrap_or_failure.yml
@@ -5,7 +5,7 @@
     from returns.result import Result
 
     x: Result[int, str]
-    reveal_type(unwrap_or_failure(x))  # N: Revealed type is 'Union[builtins.int*, builtins.str*]'
+    reveal_type(unwrap_or_failure(x))  # N: Revealed type is "Union[builtins.int*, builtins.str*]"
 
 
 - case: unwrap_or_failure_ioresult
@@ -15,7 +15,7 @@
     from returns.io import IOResult
 
     x: IOResult[int, str]
-    reveal_type(unwrap_or_failure(x))  # N: Revealed type is 'Union[returns.io.IO*[builtins.int*], returns.io.IO*[builtins.str*]]'
+    reveal_type(unwrap_or_failure(x))  # N: Revealed type is "Union[returns.io.IO*[builtins.int*], returns.io.IO*[builtins.str*]]"
 
 
 - case: unwrap_or_failure_custom_type
@@ -32,4 +32,4 @@
         ...
 
     x: MyOwn[int, str]
-    reveal_type(unwrap_or_failure(x))  # N: Revealed type is 'Union[builtins.int*, builtins.str*]'
+    reveal_type(unwrap_or_failure(x))  # N: Revealed type is "Union[builtins.int*, builtins.str*]"

--- a/typesafety/test_pipeline/test_flow/test_flow_args.yml
+++ b/typesafety/test_pipeline/test_flow/test_flow_args.yml
@@ -6,7 +6,7 @@
     reveal_type(flow())
   out: |
     main:3: error: Missing positional argument "instance" in call to "flow"
-    main:3: note: Revealed type is '<nothing>'
+    main:3: note: Revealed type is "<nothing>"
 
 
 - case: flow_one_arg
@@ -17,7 +17,7 @@
     reveal_type(flow(1))
   out: |
     main:3: error: Too few arguments for "flow"
-    main:3: note: Revealed type is '<nothing>'
+    main:3: note: Revealed type is "<nothing>"
 
 
 - case: flow_star_args
@@ -27,7 +27,7 @@
     from returns.functions import identity
 
     reveal_type(
-        flow(  # N: Revealed type is 'builtins.int*'
+        flow(  # N: Revealed type is "builtins.int*"
             1,
             identity,
             identity,

--- a/typesafety/test_pipeline/test_flow/test_flow_base.yml
+++ b/typesafety/test_pipeline/test_flow/test_flow_base.yml
@@ -6,7 +6,7 @@
     def inc(arg: int) -> int:
         ...
 
-    reveal_type(flow(1, inc, inc, inc, inc, inc))  # N: Revealed type is 'builtins.int'
+    reveal_type(flow(1, inc, inc, inc, inc, inc))  # N: Revealed type is "builtins.int"
 
 
 - case: flow_function_with_overloads1
@@ -17,7 +17,7 @@
     def convert(arg: str) -> float:
         ...
 
-    reveal_type(flow('1.0', convert, int, bool))  # N: Revealed type is 'builtins.bool*'
+    reveal_type(flow('1.0', convert, int, bool))  # N: Revealed type is "builtins.bool*"
 
 
 - case: flow_function_with_overloads2
@@ -29,7 +29,7 @@
     def convert(arg: str) -> float:
         ...
 
-    reveal_type(flow('1.0', identity, convert, identity, int, identity, bool, identity))  # N: Revealed type is 'builtins.bool*'
+    reveal_type(flow('1.0', identity, convert, identity, int, identity, bool, identity))  # N: Revealed type is "builtins.bool*"
 
 
 - case: flow_with_object1
@@ -41,7 +41,7 @@
         def __call__(self, arg: int) -> float:
             ...
 
-    reveal_type(flow(1, Test()))  # N: Revealed type is 'builtins.float'
+    reveal_type(flow(1, Test()))  # N: Revealed type is "builtins.float"
 
 
 - case: flow_with_object2
@@ -53,7 +53,7 @@
         def __init__(self, arg: int) -> None:
             ...
 
-    reveal_type(flow(1, Test))  # N: Revealed type is 'main.Test'
+    reveal_type(flow(1, Test))  # N: Revealed type is "main.Test"
 
 
 - case: flow_with_lambdas
@@ -62,7 +62,7 @@
     from returns.pipeline import flow
 
     reveal_type(
-        flow(  # N: Revealed type is 'builtins.float*'
+        flow(  # N: Revealed type is "builtins.float*"
             1,
             lambda x: x,
             str,
@@ -92,7 +92,7 @@
             ...
 
     reveal_type(
-        flow(  # N: Revealed type is 'builtins.int'
+        flow(  # N: Revealed type is "builtins.int"
             1,
             Test().method,
             Test.method_class,
@@ -110,7 +110,7 @@
     def test(arg: int) -> Any:
         ...
 
-    reveal_type(flow(1, test))  # N: Revealed type is 'Any'
+    reveal_type(flow(1, test))  # N: Revealed type is "Any"
 
 
 - case: flow_with_containers
@@ -129,7 +129,7 @@
     def mappable(arg: float) -> bool:
         ...
 
-    reveal_type(flow(x, bind(bound), identity, map_(mappable)))  # N: Revealed type is 'returns.result.Result[builtins.bool, builtins.str]'
+    reveal_type(flow(x, bind(bound), identity, map_(mappable)))  # N: Revealed type is "returns.result.Result[builtins.bool, builtins.str]"
 
 
 - case: bind_result_and_flow1
@@ -148,7 +148,7 @@
         ...
 
     r: IOResult[int, str]
-    reveal_type(flow(r, identity, bind_result(test), bind_result(second)))  # N: Revealed type is 'returns.io.IOResult[builtins.bool, builtins.str]'
+    reveal_type(flow(r, identity, bind_result(test), bind_result(second)))  # N: Revealed type is "returns.io.IOResult[builtins.bool, builtins.str]"
 
 
 - case: bind_result_and_flow2
@@ -167,7 +167,7 @@
         ...
 
     r: IOResult[int, str]
-    reveal_type(flow(r, bind_result(test), identity, bind_result(second)))  # N: Revealed type is 'returns.io.IOResult[builtins.bool, builtins.str]'
+    reveal_type(flow(r, bind_result(test), identity, bind_result(second)))  # N: Revealed type is "returns.io.IOResult[builtins.bool, builtins.str]"
 
 
 # Regression to
@@ -188,4 +188,4 @@
         ...
 
     r: IOResult[int, str]
-    reveal_type(flow(r, bind_result(test), bind_result(second)))  # N: Revealed type is 'returns.io.IOResult[builtins.bool, builtins.str]'
+    reveal_type(flow(r, bind_result(test), bind_result(second)))  # N: Revealed type is "returns.io.IOResult[builtins.bool, builtins.str]"

--- a/typesafety/test_pipeline/test_flow/test_flow_curry.yml
+++ b/typesafety/test_pipeline/test_flow/test_flow_curry.yml
@@ -9,7 +9,7 @@
     def curried(a: int, b: int) -> float:
         ...
 
-    reveal_type(flow(1, curried)(1))  # N: Revealed type is 'builtins.float'
+    reveal_type(flow(1, curried)(1))  # N: Revealed type is "builtins.float"
 
 
 - case: flow_function_with_curried2
@@ -23,4 +23,4 @@
     def curried(a: int, b: int) -> float:
         ...
 
-    reveal_type(flow(1, curried, identity)(1))  # N: Revealed type is 'builtins.float'
+    reveal_type(flow(1, curried, identity)(1))  # N: Revealed type is "builtins.float"

--- a/typesafety/test_pipeline/test_flow/test_flow_errors.yml
+++ b/typesafety/test_pipeline/test_flow/test_flow_errors.yml
@@ -9,7 +9,7 @@
     reveal_type(flow('1', int, convert))
   out: |
     main:6: error: Argument 1 to "convert" has incompatible type "int"; expected "str"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"
 
 
 - case: flow_wrong_steps_error
@@ -20,7 +20,7 @@
     reveal_type(flow('a', [], int))
   out: |
     main:3: error: "List[<nothing>]" not callable
-    main:3: note: Revealed type is 'builtins.int*'
+    main:3: note: Revealed type is "builtins.int*"
 
 
 - case: flow_function_first_arg_error
@@ -34,7 +34,7 @@
     reveal_type(flow(1, convert))
   out: |
     main:6: error: Argument 1 to "convert" has incompatible type "int"; expected "str"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"
 
 
 - case: flow_function_without_args_error
@@ -48,7 +48,7 @@
     reveal_type(flow(1, convert))
   out: |
     main:6: error: Too many arguments for "convert"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"
 
 
 - case: flow_function_with_too_many_args_error
@@ -63,4 +63,4 @@
   out: |
     main:6: error: Argument 1 to "convert" has incompatible type "int"; expected "str"
     main:6: error: Missing positional argument "other" in call to "convert"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"

--- a/typesafety/test_pipeline/test_flow/test_flow_generics.yml
+++ b/typesafety/test_pipeline/test_flow/test_flow_generics.yml
@@ -9,7 +9,7 @@
 
     def test(arg: _NewValueType) -> _NewValueType:
         x = flow(arg, identity)
-        reveal_type(x)  # N: Revealed type is '_NewValueType`-1'
+        reveal_type(x)  # N: Revealed type is "_NewValueType`-1"
         return x
 
 
@@ -24,5 +24,5 @@
 
     def test(arg: _NewValueType) -> _NewValueType:
         x = flow(arg, str)
-        reveal_type(x)  # N: Revealed type is 'builtins.str*'
+        reveal_type(x)  # N: Revealed type is "builtins.str*"
         return arg

--- a/typesafety/test_pipeline/test_is_successful.yml
+++ b/typesafety/test_pipeline/test_is_successful.yml
@@ -7,7 +7,7 @@
     def returns_result() -> Result[int, str]:
         ...
 
-    reveal_type(is_successful(returns_result()))  # N: Revealed type is 'builtins.bool'
+    reveal_type(is_successful(returns_result()))  # N: Revealed type is "builtins.bool"
 
 
 - case: ioresult_is_successful
@@ -19,7 +19,7 @@
     def returns_ioresult() -> IOResult[int, str]:
         ...
 
-    reveal_type(is_successful(returns_ioresult()))  # N: Revealed type is 'builtins.bool'
+    reveal_type(is_successful(returns_ioresult()))  # N: Revealed type is "builtins.bool"
 
 
 - case: maybe_is_successful
@@ -28,7 +28,7 @@
     from returns.pipeline import is_successful
     from returns.maybe import Maybe
 
-    reveal_type(is_successful(Maybe.from_value(1)))  # N: Revealed type is 'builtins.bool'
+    reveal_type(is_successful(Maybe.from_value(1)))  # N: Revealed type is "builtins.bool"
 
 
 - case: custom_type_is_successful
@@ -62,6 +62,6 @@
             return self.error
 
     x: MyOwn[int, str]
-    reveal_type(x.unwrap())  # N: Revealed type is 'builtins.int*'
-    reveal_type(x.failure())  # N: Revealed type is 'builtins.str*'
-    reveal_type(is_successful(x))  # N: Revealed type is 'builtins.bool'
+    reveal_type(x.unwrap())  # N: Revealed type is "builtins.int*"
+    reveal_type(x.failure())  # N: Revealed type is "builtins.str*"
+    reveal_type(is_successful(x))  # N: Revealed type is "builtins.bool"

--- a/typesafety/test_pipeline/test_managed/test_managed_types.yml
+++ b/typesafety/test_pipeline/test_managed/test_managed_types.yml
@@ -15,7 +15,7 @@
         ...
 
     x: IOResult[int, str]
-    reveal_type(managed(use, release)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.float, builtins.str]'
+    reveal_type(managed(use, release)(x))  # N: Revealed type is "returns.io.IOResult[builtins.float, builtins.str]"
 
 
 - case: managed_with_future_result
@@ -35,7 +35,7 @@
         ...
 
     x: FutureResult[int, str]
-    reveal_type(managed(use, release)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.float, builtins.str]'
+    reveal_type(managed(use, release)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.float, builtins.str]"
 
 
 - case: managed_with_reader_ioresult
@@ -55,7 +55,7 @@
         ...
 
     x: ReaderIOResult[int, str, bool]
-    reveal_type(managed(use, release)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.str, builtins.bool]'
+    reveal_type(managed(use, release)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.str, builtins.bool]"
 
 
 - case: managed_with_reader_future_result
@@ -75,7 +75,7 @@
         ...
 
     x: ReaderFutureResult[int, str, bool]
-    reveal_type(managed(use, release)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.str, builtins.bool]'
+    reveal_type(managed(use, release)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.str, builtins.bool]"
 
 
 - case: managed_custom_type
@@ -130,4 +130,4 @@
         ...
 
     x: MyClass[int, str]
-    reveal_type(managed(use, release)(x))  # N: Revealed type is 'main.MyClass[builtins.float, builtins.str]'
+    reveal_type(managed(use, release)(x))  # N: Revealed type is "main.MyClass[builtins.float, builtins.str]"

--- a/typesafety/test_pipeline/test_pipe/test_pipe_base.yml
+++ b/typesafety/test_pipeline/test_pipe/test_pipe_base.yml
@@ -7,7 +7,7 @@
         ...
 
     predefined = pipe(convert, int, bool)
-    reveal_type(predefined('1.0'))  # N: Revealed type is 'builtins.bool*'
+    reveal_type(predefined('1.0'))  # N: Revealed type is "builtins.bool*"
 
 
 - case: pipe_function2
@@ -20,7 +20,7 @@
         ...
 
     predefined = pipe(identity, convert, identity, identity, int, identity, bool, identity)
-    reveal_type(predefined('1.0'))  # N: Revealed type is 'builtins.bool*'
+    reveal_type(predefined('1.0'))  # N: Revealed type is "builtins.bool*"
 
 
 - case: pipe_callable_instances
@@ -42,7 +42,7 @@
         ...
 
     predefined = pipe(Test, with_instance, convert, Test(1))
-    reveal_type(predefined(1))  # N: Revealed type is 'builtins.bool'
+    reveal_type(predefined(1))  # N: Revealed type is "builtins.bool"
 
 
 - case: pipe_star_args
@@ -52,7 +52,7 @@
     from returns.functions import identity
 
     reveal_type(
-        pipe(  # N: Revealed type is 'builtins.int*'
+        pipe(  # N: Revealed type is "builtins.int*"
             identity,
             identity,
             identity,
@@ -78,7 +78,7 @@
     from returns.pipeline import pipe
 
     reveal_type(
-        pipe(  # N: Revealed type is 'builtins.float*'
+        pipe(  # N: Revealed type is "builtins.float*"
             lambda x: x,
             str,
             lambda y: y.split(' '),
@@ -107,7 +107,7 @@
             ...
 
     reveal_type(
-        pipe(  # N: Revealed type is 'builtins.int'
+        pipe(  # N: Revealed type is "builtins.int"
             Test().method,
             Test.method_class,
             Test.method_static,
@@ -124,7 +124,7 @@
     def test(arg: int) -> Any:
         ...
 
-    reveal_type(pipe(test)(1))  # N: Revealed type is 'Any'
+    reveal_type(pipe(test)(1))  # N: Revealed type is "Any"
 
 
 - case: pipe_with_overloads
@@ -133,8 +133,8 @@
     from returns.pipeline import pipe
 
     x = pipe(int, str, int)
-    reveal_type(x(1.0))  # N: Revealed type is 'builtins.int*'
-    reveal_type(x('a'))  # N: Revealed type is 'builtins.int*'
+    reveal_type(x(1.0))  # N: Revealed type is "builtins.int*"
+    reveal_type(x('a'))  # N: Revealed type is "builtins.int*"
 
 
 - case: pipe_with_containers
@@ -153,7 +153,7 @@
     def mappable(arg: float) -> bool:
         ...
 
-    reveal_type(pipe(bind(bound), identity, map_(mappable))(x))  # N: Revealed type is 'returns.result.Result[builtins.bool, builtins.str]'
+    reveal_type(pipe(bind(bound), identity, map_(mappable))(x))  # N: Revealed type is "returns.result.Result[builtins.bool, builtins.str]"
 
 
 - case: pipe_with_containers2
@@ -172,4 +172,4 @@
         ...
 
     r: IOResult[int, str]
-    reveal_type(pipe(bind_result(test), bind_result(second))(r))  # N: Revealed type is 'returns.io.IOResult[builtins.bool, builtins.str]'
+    reveal_type(pipe(bind_result(test), bind_result(second))(r))  # N: Revealed type is "returns.io.IOResult[builtins.bool, builtins.str]"

--- a/typesafety/test_pipeline/test_pipe/test_pipe_callable_protocol.yml
+++ b/typesafety/test_pipeline/test_pipe/test_pipe_callable_protocol.yml
@@ -11,7 +11,7 @@
         return f('a')
 
     predefined = pipe(convert, int, bool)
-    reveal_type(callback(predefined))  # N: Revealed type is 'builtins.bool'
+    reveal_type(callback(predefined))  # N: Revealed type is "builtins.bool"
 
 
 - case: pipe_generic_callable1
@@ -33,7 +33,7 @@
         ...
 
     predefined = pipe(first, second)
-    reveal_type(callback(predefined, 1))  # N: Revealed type is 'builtins.str*'
+    reveal_type(callback(predefined, 1))  # N: Revealed type is "builtins.str*"
 
 
 - case: pipe_generic_callable2
@@ -55,4 +55,4 @@
         ...
 
     predefined = pipe(first, second)
-    reveal_type(callback(predefined))  # N: Revealed type is 'builtins.str*'
+    reveal_type(callback(predefined))  # N: Revealed type is "builtins.str*"

--- a/typesafety/test_pipeline/test_pipe/test_pipe_curry.yml
+++ b/typesafety/test_pipeline/test_pipe/test_pipe_curry.yml
@@ -9,4 +9,4 @@
     def curried(a: int, b: int) -> float:
         ...
 
-    reveal_type(pipe(curried, identity)(1)(2))  # N: Revealed type is 'builtins.float'
+    reveal_type(pipe(curried, identity)(1)(2))  # N: Revealed type is "builtins.float"

--- a/typesafety/test_pipeline/test_pipe/test_pipe_errors.yml
+++ b/typesafety/test_pipeline/test_pipe/test_pipe_errors.yml
@@ -9,7 +9,7 @@
     reveal_type(pipe(int, convert)('a'))
   out: |
     main:6: error: Argument 1 to "convert" has incompatible type "int"; expected "str"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"
 
 
 - case: pipe_wrong_steps_error
@@ -46,7 +46,7 @@
   out: |
     main:6: error: Argument 1 to "__call__" of "_Pipe" has incompatible type "int"; expected "str"
     main:6: error: Argument 1 to "convert" has incompatible type "int"; expected "str"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"
 
 
 - case: pipe_function_without_args_error
@@ -60,7 +60,7 @@
     reveal_type(pipe(convert)(1))
   out: |
     main:6: error: Too many arguments for "convert"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"
 
 
 - case: pipe_function_with_too_many_args_error
@@ -76,4 +76,4 @@
     main:6: error: Argument 1 to "__call__" of "_Pipe" has incompatible type "int"; expected "str"
     main:6: error: Argument 1 to "convert" has incompatible type "int"; expected "str"
     main:6: error: Missing positional argument "other" in call to "convert"
-    main:6: note: Revealed type is 'builtins.float'
+    main:6: note: Revealed type is "builtins.float"

--- a/typesafety/test_pipeline/test_pipe/test_pipe_generic.yml
+++ b/typesafety/test_pipeline/test_pipe/test_pipe_generic.yml
@@ -9,7 +9,7 @@
 
     def test(arg: _NewValueType) -> _NewValueType:
         x = pipe(identity)(arg)
-        reveal_type(x)  # N: Revealed type is '_NewValueType`-1'
+        reveal_type(x)  # N: Revealed type is "_NewValueType`-1"
         return x
 
 
@@ -24,5 +24,5 @@
 
     def test(arg: _NewValueType) -> _NewValueType:
         x = pipe(identity, str)(arg)
-        reveal_type(x)  # N: Revealed type is 'builtins.str*'
+        reveal_type(x)  # N: Revealed type is "builtins.str*"
         return arg

--- a/typesafety/test_pointfree/test_alt.yml
+++ b/typesafety/test_pointfree/test_alt.yml
@@ -12,7 +12,7 @@
         ...
 
     r: Result[str, int]
-    reveal_type(flow(r, alt(test), alt(stringify)))  # N: Revealed type is 'returns.result.Result[builtins.str, builtins.str]'
+    reveal_type(flow(r, alt(test), alt(stringify)))  # N: Revealed type is "returns.result.Result[builtins.str, builtins.str]"
 
 
 - case: alt_result
@@ -25,7 +25,7 @@
         ...
 
     x: Result[str, float]
-    reveal_type(alt(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.str, builtins.int]'
+    reveal_type(alt(test)(x))  # N: Revealed type is "returns.result.Result[builtins.str, builtins.int]"
 
 
 - case: alt_ioresult
@@ -38,7 +38,7 @@
         ...
 
     x: IOResult[str, float]
-    reveal_type(alt(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.str, builtins.int]'
+    reveal_type(alt(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.str, builtins.int]"
 
 
 - case: alt_requires_context_result
@@ -51,7 +51,7 @@
         ...
 
     x: RequiresContextResult[str, float, bool]
-    reveal_type(alt(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.str, builtins.int, builtins.bool]'
+    reveal_type(alt(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.str, builtins.int, builtins.bool]"
 
 
 - case: alt_requires_context_ioresult
@@ -64,7 +64,7 @@
         ...
 
     x: RequiresContextIOResult[str, float, bool]
-    reveal_type(alt(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.int, builtins.bool]'
+    reveal_type(alt(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.int, builtins.bool]"
 
 
 - case: alt_requires_context_future_result
@@ -77,7 +77,7 @@
         ...
 
     x: RequiresContextFutureResult[str, float, bool]
-    reveal_type(alt(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str, builtins.int, builtins.bool]'
+    reveal_type(alt(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str, builtins.int, builtins.bool]"
 
 
 - case: alt_future_result
@@ -90,7 +90,7 @@
         ...
 
     x: FutureResult[str, float]
-    reveal_type(alt(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.str, builtins.int]'
+    reveal_type(alt(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.str, builtins.int]"
 
 
 - case: alt_custom_type
@@ -114,4 +114,4 @@
         ...
 
     x: MyOwn[str, float]
-    reveal_type(alt(test)(x))  # N: Revealed type is 'main.MyOwn[builtins.str, builtins.int]'
+    reveal_type(alt(test)(x))  # N: Revealed type is "main.MyOwn[builtins.str, builtins.int]"

--- a/typesafety/test_pointfree/test_apply.yml
+++ b/typesafety/test_pointfree/test_apply.yml
@@ -9,7 +9,7 @@
     test: Result[Callable[[float], int], str]
     x: Result[float, str]
 
-    reveal_type(flow(test, x.apply))  # N: Revealed type is 'returns.result.Result[builtins.int*, builtins.str]'
+    reveal_type(flow(test, x.apply))  # N: Revealed type is "returns.result.Result[builtins.int*, builtins.str]"
 
 
 - case: apply_wrong_extra_types
@@ -48,7 +48,7 @@
         ...
 
     x: IO[float]
-    reveal_type(apply(IO(test))(x))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(apply(IO(test))(x))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 
 - case: apply_maybe
@@ -61,7 +61,7 @@
         ...
 
     x: Maybe[float]
-    reveal_type(apply(Maybe.from_value(test))(x))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int]'
+    reveal_type(apply(Maybe.from_value(test))(x))  # N: Revealed type is "returns.maybe.Maybe[builtins.int]"
 
 
 - case: apply_result
@@ -74,7 +74,7 @@
     test: Result[Callable[[float], int], str]
     x: Result[float, str]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: apply_ioresult
@@ -87,7 +87,7 @@
     test: IOResult[Callable[[float], int], str]
     x: IOResult[float, str]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: apply_requires_context
@@ -100,7 +100,7 @@
     test: RequiresContext[Callable[[float], int], bool]
     x: RequiresContext[float, bool]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int, builtins.bool]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int, builtins.bool]"
 
 
 - case: apply_requires_context_result
@@ -113,7 +113,7 @@
     test: RequiresContextResult[Callable[[float], int], str, bool]
     x: RequiresContextResult[float, str, bool]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: apply_requires_context_ioresult
@@ -126,7 +126,7 @@
     test: RequiresContextIOResult[Callable[[float], int], str, bool]
     x: RequiresContextIOResult[float, str, bool]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: apply_requires_context_future_result
@@ -139,7 +139,7 @@
     test: RequiresContextFutureResult[Callable[[float], int], str, bool]
     x: RequiresContextFutureResult[float, str, bool]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: apply_future
@@ -152,7 +152,7 @@
         ...
 
     x: Future[float]
-    reveal_type(apply(Future.from_value(test))(x))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(apply(Future.from_value(test))(x))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: apply_future_result
@@ -165,7 +165,7 @@
     test: FutureResult[Callable[[float], int], str]
     x: FutureResult[float, str]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: apply_custom_type
@@ -185,4 +185,4 @@
     test: MyClass[Callable[[float], int]]
     x: MyClass[float]
 
-    reveal_type(apply(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int]'
+    reveal_type(apply(test)(x))  # N: Revealed type is "main.MyClass[builtins.int]"

--- a/typesafety/test_pointfree/test_bimap.yml
+++ b/typesafety/test_pointfree/test_bimap.yml
@@ -12,7 +12,7 @@
         ...
 
     r: Result[float, int]
-    reveal_type(flow(r, bimap(first, second)))  # N: Revealed type is 'returns.result.Result[builtins.str, builtins.str]'
+    reveal_type(flow(r, bimap(first, second)))  # N: Revealed type is "returns.result.Result[builtins.str, builtins.str]"
 
 
 - case: bimap_result
@@ -28,7 +28,7 @@
         ...
 
     x: Result[float, int]
-    reveal_type(bimap(first, second)(x))  # N: Revealed type is 'returns.result.Result[builtins.str, builtins.str]'
+    reveal_type(bimap(first, second)(x))  # N: Revealed type is "returns.result.Result[builtins.str, builtins.str]"
 
 
 - case: bimap_ioresult
@@ -44,7 +44,7 @@
         ...
 
     x: IOResult[float, int]
-    reveal_type(bimap(first, second)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.str, builtins.str]'
+    reveal_type(bimap(first, second)(x))  # N: Revealed type is "returns.io.IOResult[builtins.str, builtins.str]"
 
 
 - case: bimap_requires_context_result
@@ -60,7 +60,7 @@
         ...
 
     x: RequiresContextResult[float, int, bool]
-    reveal_type(bimap(first, second)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.str, builtins.str, builtins.bool]'
+    reveal_type(bimap(first, second)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.str, builtins.str, builtins.bool]"
 
 
 - case: bimap_requires_context_ioresult
@@ -76,7 +76,7 @@
         ...
 
     x: RequiresContextIOResult[float, int, bool]
-    reveal_type(bimap(first, second)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.str, builtins.bool]'
+    reveal_type(bimap(first, second)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.str, builtins.str, builtins.bool]"
 
 
 - case: bimap_requires_context_future_result
@@ -92,7 +92,7 @@
         ...
 
     x: RequiresContextFutureResult[float, int, bool]
-    reveal_type(bimap(first, second)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str, builtins.str, builtins.bool]'
+    reveal_type(bimap(first, second)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str, builtins.str, builtins.bool]"
 
 
 - case: bimap_future_result
@@ -108,7 +108,7 @@
         ...
 
     x: FutureResult[float, int]
-    reveal_type(bimap(first, second)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.str, builtins.str]'
+    reveal_type(bimap(first, second)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.str, builtins.str]"
 
 
 - case: bimap_custom_type
@@ -135,4 +135,4 @@
         ...
 
     x: MyOwn[float, int]
-    reveal_type(bimap(first, second)(x))  # N: Revealed type is 'main.MyOwn[builtins.str, builtins.str]'
+    reveal_type(bimap(first, second)(x))  # N: Revealed type is "main.MyOwn[builtins.str, builtins.str]"

--- a/typesafety/test_pointfree/test_bind.yml
+++ b/typesafety/test_pointfree/test_bind.yml
@@ -12,7 +12,7 @@
         ...
 
     x: Maybe[B]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.maybe.Maybe[main.C]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.maybe.Maybe[main.C]"
 
 
 - case: bind_wrong_instance_type
@@ -56,7 +56,7 @@
         ...
 
     x: Result[float, str]
-    reveal_type(flow(x, bind(test)))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(flow(x, bind(test)))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: bind_io
@@ -69,7 +69,7 @@
         ...
 
     x: IO[float]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 
 - case: bind_maybe
@@ -82,7 +82,7 @@
         ...
 
     x: Maybe[float]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.maybe.Maybe[builtins.int]"
 
 
 - case: bind_result
@@ -95,7 +95,7 @@
         ...
 
     x: Result[float, str]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: bind_ioresult
@@ -108,7 +108,7 @@
         ...
 
     x: IOResult[float, str]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: bind_requires_context
@@ -121,7 +121,7 @@
         ...
 
     x: RequiresContext[float, str]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int, builtins.str]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int, builtins.str]"
 
 
 - case: bind_requires_context_result
@@ -134,7 +134,7 @@
         ...
 
     x: RequiresContextResult[float, bool, str]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_requires_context_ioresult
@@ -147,7 +147,7 @@
         ...
 
     x: RequiresContextIOResult[float, bool, str]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_requires_context_future_result
@@ -160,7 +160,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_future
@@ -173,7 +173,7 @@
         ...
 
     x: Future[float]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: bind_future_result
@@ -186,7 +186,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_custom_type
@@ -210,4 +210,4 @@
         ...
 
     x: MyOwn[float]
-    reveal_type(bind(test)(x))  # N: Revealed type is 'main.MyOwn[builtins.int]'
+    reveal_type(bind(test)(x))  # N: Revealed type is "main.MyOwn[builtins.int]"

--- a/typesafety/test_pointfree/test_bind_async.yml
+++ b/typesafety/test_pointfree/test_bind_async.yml
@@ -70,7 +70,7 @@
         ...
 
     x: Future[float]
-    reveal_type(flow(x, bind_async(test1), bind_async(test2)))  # N: Revealed type is 'returns.future.Future[builtins.str]'
+    reveal_type(flow(x, bind_async(test1), bind_async(test2)))  # N: Revealed type is "returns.future.Future[builtins.str]"
 
 
 - case: bind_async_requires_context_future_result
@@ -83,7 +83,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind_async(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_async(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_async_future
@@ -96,7 +96,7 @@
         ...
 
     x: Future[float]
-    reveal_type(bind_async(test)(x))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(bind_async(test)(x))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: bind_async_future_result
@@ -109,7 +109,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_async(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_async(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_async_custom_type
@@ -132,4 +132,4 @@
         ...
 
     x: MyClass[float]
-    reveal_type(bind_async(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int]'
+    reveal_type(bind_async(test)(x))  # N: Revealed type is "main.MyClass[builtins.int]"

--- a/typesafety/test_pointfree/test_bind_async_context_future_result.yml
+++ b/typesafety/test_pointfree/test_bind_async_context_future_result.yml
@@ -21,4 +21,4 @@
         ...
 
     x: RequiresContextFutureResult[float, str, bool]
-    reveal_type(bind_async_context_future_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_async_context_future_result(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"

--- a/typesafety/test_pointfree/test_bind_async_future.yml
+++ b/typesafety/test_pointfree/test_bind_async_future.yml
@@ -12,7 +12,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(flow(x, bind_async_future(test1), bind_async_future(test2)))  # N: Revealed type is 'returns.future.FutureResult[builtins.str, builtins.str]'
+    reveal_type(flow(x, bind_async_future(test1), bind_async_future(test2)))  # N: Revealed type is "returns.future.FutureResult[builtins.str, builtins.str]"
 
 
 - case: bind_async_future_requires_context_future_result
@@ -26,7 +26,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind_async_future(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_async_future(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_async_future_future
@@ -39,7 +39,7 @@
         ...
 
     x: Future[float]
-    reveal_type(bind_async_future(test)(x))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(bind_async_future(test)(x))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: bind_async_future_future_result
@@ -52,7 +52,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_async_future(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_async_future(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_async_future_custom_type
@@ -77,4 +77,4 @@
         ...
 
     x: MyClass[float]
-    reveal_type(bind_async_future(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int]'
+    reveal_type(bind_async_future(test)(x))  # N: Revealed type is "main.MyClass[builtins.int]"

--- a/typesafety/test_pointfree/test_bind_async_future_result.yml
+++ b/typesafety/test_pointfree/test_bind_async_future_result.yml
@@ -35,7 +35,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind_async_future_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_async_future_result(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_async_future_result_future_result
@@ -48,7 +48,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_async_future_result(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_async_future_result(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_async_future_result_custom_type
@@ -73,4 +73,4 @@
         ...
 
     x: MyClass[float, str]
-    reveal_type(bind_async_future_result(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.str]'
+    reveal_type(bind_async_future_result(test)(x))  # N: Revealed type is "main.MyClass[builtins.int, builtins.str]"

--- a/typesafety/test_pointfree/test_bind_awaitable.yml
+++ b/typesafety/test_pointfree/test_bind_awaitable.yml
@@ -54,7 +54,7 @@
         ...
 
     x: Future[float]
-    reveal_type(flow(x, bind_awaitable(test1), bind_awaitable(test2)))  # N: Revealed type is 'returns.future.Future[builtins.str]'
+    reveal_type(flow(x, bind_awaitable(test1), bind_awaitable(test2)))  # N: Revealed type is "returns.future.Future[builtins.str]"
 
 
 - case: bind_awaitable_requires_context_future_result
@@ -67,7 +67,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_awaitable_future
@@ -80,7 +80,7 @@
         ...
 
     x: Future[float]
-    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: bind_awaitable_future_result
@@ -93,7 +93,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_awaitable_custom_type
@@ -118,4 +118,4 @@
         ...
 
     x: MyClass[float]
-    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int]'
+    reveal_type(bind_awaitable(test)(x))  # N: Revealed type is "main.MyClass[builtins.int]"

--- a/typesafety/test_pointfree/test_bind_context2.yml
+++ b/typesafety/test_pointfree/test_bind_context2.yml
@@ -43,7 +43,7 @@
         ...
 
     r: RequiresContext[int, str]
-    reveal_type(flow(r, bind_context2(test), bind_context2(second)))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.bool, builtins.str]'
+    reveal_type(flow(r, bind_context2(test), bind_context2(second)))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.bool, builtins.str]"
 
 
 - case: bind_context2_requires_context
@@ -56,7 +56,7 @@
         ...
 
     x: RequiresContext[float, str]
-    reveal_type(bind_context2(test)(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int, builtins.str]'
+    reveal_type(bind_context2(test)(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int, builtins.str]"
 
 
 - case: bind_context2_custom_type
@@ -82,4 +82,4 @@
         ...
 
     x: MyClass[int, str]
-    reveal_type(bind_context2(test)(x))  # N: Revealed type is 'main.MyClass[builtins.float, builtins.str]'
+    reveal_type(bind_context2(test)(x))  # N: Revealed type is "main.MyClass[builtins.float, builtins.str]"

--- a/typesafety/test_pointfree/test_bind_context3.yml
+++ b/typesafety/test_pointfree/test_bind_context3.yml
@@ -38,7 +38,7 @@
         ...
 
     x: RequiresContextResult[float, Exception, str]
-    reveal_type(bind_context3(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.Exception, builtins.str]'
+    reveal_type(bind_context3(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.Exception, builtins.str]"
 
 
 - case: bind_context_and_flow
@@ -55,7 +55,7 @@
         ...
 
     r: RequiresContextResult[int, Exception, str]
-    reveal_type(flow(r, bind_context(test), bind_context(second)))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.bool, builtins.Exception, builtins.str]'
+    reveal_type(flow(r, bind_context(test), bind_context(second)))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.bool, builtins.Exception, builtins.str]"
 
 
 - case: bind_context_requires_context_result
@@ -68,7 +68,7 @@
         ...
 
     x: RequiresContextResult[float, Exception, str]
-    reveal_type(bind_context(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.Exception, builtins.str]'
+    reveal_type(bind_context(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.Exception, builtins.str]"
 
 
 - case: bind_context_requires_context_ioresult
@@ -81,7 +81,7 @@
         ...
 
     x: RequiresContextIOResult[float, Exception, str]
-    reveal_type(bind_context(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.Exception, builtins.str]'
+    reveal_type(bind_context(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.Exception, builtins.str]"
 
 
 - case: bind_context_requires_context_future_result
@@ -94,7 +94,7 @@
         ...
 
     x: RequiresContextFutureResult[float, Exception, str]
-    reveal_type(bind_context(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.Exception, builtins.str]'
+    reveal_type(bind_context(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.Exception, builtins.str]"
 
 
 - case: bind_context_custom_type
@@ -120,4 +120,4 @@
         ...
 
     x: MyClass[int, Exception, str]
-    reveal_type(bind_context(test)(x))  # N: Revealed type is 'main.MyClass[builtins.float, builtins.Exception, builtins.str]'
+    reveal_type(bind_context(test)(x))  # N: Revealed type is "main.MyClass[builtins.float, builtins.Exception, builtins.str]"

--- a/typesafety/test_pointfree/test_bind_context_future_result.yml
+++ b/typesafety/test_pointfree/test_bind_context_future_result.yml
@@ -21,4 +21,4 @@
         ...
 
     x: RequiresContextFutureResult[float, str, bool]
-    reveal_type(bind_context_future_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_context_future_result(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"

--- a/typesafety/test_pointfree/test_bind_context_ioresult.yml
+++ b/typesafety/test_pointfree/test_bind_context_ioresult.yml
@@ -21,7 +21,7 @@
         ...
 
     x: RequiresContextIOResult[float, str, bool]
-    reveal_type(bind_context_ioresult(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_context_ioresult(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_context_ioresult_requires_context_future_result
@@ -34,4 +34,4 @@
         ...
 
     x: RequiresContextFutureResult[float, str, bool]
-    reveal_type(bind_context_ioresult(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_context_ioresult(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"

--- a/typesafety/test_pointfree/test_bind_context_result.yml
+++ b/typesafety/test_pointfree/test_bind_context_result.yml
@@ -21,7 +21,7 @@
         ...
 
     x: RequiresContextResult[float, str, bool]
-    reveal_type(bind_context_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_context_result(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_context_result_requires_context_ioresult
@@ -34,7 +34,7 @@
         ...
 
     x: RequiresContextIOResult[float, str, bool]
-    reveal_type(bind_context_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_context_result(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_context_result_requires_context_future_result
@@ -47,4 +47,4 @@
         ...
 
     x: RequiresContextFutureResult[float, str, bool]
-    reveal_type(bind_context_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_context_result(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"

--- a/typesafety/test_pointfree/test_bind_future.yml
+++ b/typesafety/test_pointfree/test_bind_future.yml
@@ -12,7 +12,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(flow(x, bind_future(test1), bind_future(test2)))  # N: Revealed type is 'returns.future.FutureResult[builtins.str, builtins.str]'
+    reveal_type(flow(x, bind_future(test1), bind_future(test2)))  # N: Revealed type is "returns.future.FutureResult[builtins.str, builtins.str]"
 
 
 - case: bind_future_wrong_function
@@ -39,7 +39,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind_future(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_future(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_future_future
@@ -52,7 +52,7 @@
         ...
 
     x: Future[float]
-    reveal_type(bind_future(test)(x))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(bind_future(test)(x))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: bind_future_future_result
@@ -65,7 +65,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_future(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_future(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_future_custom_type
@@ -89,4 +89,4 @@
         ...
 
     x: MyClass[float]
-    reveal_type(bind_future(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int]'
+    reveal_type(bind_future(test)(x))  # N: Revealed type is "main.MyClass[builtins.int]"

--- a/typesafety/test_pointfree/test_bind_future_result.yml
+++ b/typesafety/test_pointfree/test_bind_future_result.yml
@@ -35,7 +35,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind_future_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_future_result(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_future_result_future_result
@@ -48,7 +48,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_future_result(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_future_result(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_future_result_custom_type
@@ -73,4 +73,4 @@
         ...
 
     x: MyClass[float, str]
-    reveal_type(bind_future_result(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.str]'
+    reveal_type(bind_future_result(test)(x))  # N: Revealed type is "main.MyClass[builtins.int, builtins.str]"

--- a/typesafety/test_pointfree/test_bind_io.yml
+++ b/typesafety/test_pointfree/test_bind_io.yml
@@ -12,7 +12,7 @@
         ...
 
     x: IO[B]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'returns.io.IO[main.C]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "returns.io.IO[main.C]"
 
 
 - case: bind_io_with_flow
@@ -26,7 +26,7 @@
         ...
 
     x: IO[float]
-    reveal_type(flow(x, bind_io(test)))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(flow(x, bind_io(test)))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 
 - case: bind_io_wrong_instance_type
@@ -71,7 +71,7 @@
         ...
 
     x: IO[float]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 - case: bind_io_ioresult
   disable_cache: false
@@ -83,7 +83,7 @@
         ...
 
     x: IOResult[float, str]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: bind_io_requires_context_ioresult
@@ -97,7 +97,7 @@
         ...
 
     x: RequiresContextIOResult[float, bool, str]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_io_requires_context_future_result
@@ -111,7 +111,7 @@
         ...
 
     x: RequiresContextFutureResult[float, bool, str]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.bool, builtins.str]"
 
 
 - case: bind_io_future
@@ -125,7 +125,7 @@
         ...
 
     x: Future[float]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: bind_io_future_result
@@ -139,7 +139,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_io_custom_type
@@ -163,4 +163,4 @@
         ...
 
     x: MyClass[float]
-    reveal_type(bind_io(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int]'
+    reveal_type(bind_io(test)(x))  # N: Revealed type is "main.MyClass[builtins.int]"

--- a/typesafety/test_pointfree/test_bind_ioresult.yml
+++ b/typesafety/test_pointfree/test_bind_ioresult.yml
@@ -14,7 +14,7 @@
         ...
 
     r: FutureResult[int, str]
-    reveal_type(flow(r, bind_ioresult(test), bind_ioresult(second)))  # N: Revealed type is 'returns.future.FutureResult[builtins.bool, builtins.str]'
+    reveal_type(flow(r, bind_ioresult(test), bind_ioresult(second)))  # N: Revealed type is "returns.future.FutureResult[builtins.bool, builtins.str]"
 
 
 - case: bind_ioresult_wrong_first_type
@@ -69,7 +69,7 @@
         ...
 
     x: IOResult[float, str]
-    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: bind_ioresult_requires_context_ioresult
@@ -83,7 +83,7 @@
         ...
 
     x: RequiresContextIOResult[float, str, bool]
-    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_ioresult_requires_context_future_result
@@ -97,7 +97,7 @@
         ...
 
     x: RequiresContextFutureResult[float, str, bool]
-    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_ioresult_future_result
@@ -111,7 +111,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_ioresult_custom_type
@@ -136,4 +136,4 @@
         ...
 
     x: MyClass[int, str]
-    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is 'main.MyClass[builtins.float, builtins.str]'
+    reveal_type(bind_ioresult(test)(x))  # N: Revealed type is "main.MyClass[builtins.float, builtins.str]"

--- a/typesafety/test_pointfree/test_bind_optional.yml
+++ b/typesafety/test_pointfree/test_bind_optional.yml
@@ -25,4 +25,4 @@
         ...
 
     x: Maybe[float]
-    reveal_type(bind_optional(test)(x))  # N: Revealed type is 'returns.maybe.Maybe[builtins.str]'
+    reveal_type(bind_optional(test)(x))  # N: Revealed type is "returns.maybe.Maybe[builtins.str]"

--- a/typesafety/test_pointfree/test_bind_result.yml
+++ b/typesafety/test_pointfree/test_bind_result.yml
@@ -14,7 +14,7 @@
         ...
 
     r: IOResult[int, str]
-    reveal_type(flow(r, bind_result(test), bind_result(second)))  # N: Revealed type is 'returns.io.IOResult[builtins.bool, builtins.str]'
+    reveal_type(flow(r, bind_result(test), bind_result(second)))  # N: Revealed type is "returns.io.IOResult[builtins.bool, builtins.str]"
 
 
 - case: bind_result_wrong_first_type
@@ -55,7 +55,7 @@
         ...
 
     x: Result[float, str]
-    reveal_type(bind_result(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(bind_result(test)(x))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: bind_result_ioresult
@@ -69,7 +69,7 @@
         ...
 
     x: IOResult[float, str]
-    reveal_type(bind_result(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(bind_result(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: bind_result_requires_context_result
@@ -83,7 +83,7 @@
         ...
 
     x: RequiresContextResult[float, str, bool]
-    reveal_type(bind_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_result(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_result_requires_context_ioresult
@@ -97,7 +97,7 @@
         ...
 
     x: RequiresContextIOResult[float, str, bool]
-    reveal_type(bind_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_result(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_result_requires_context_future_result
@@ -111,7 +111,7 @@
         ...
 
     x: RequiresContextFutureResult[float, str, bool]
-    reveal_type(bind_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(bind_result(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: bind_result_future_result
@@ -125,7 +125,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(bind_result(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(bind_result(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: bind_result_custom_type
@@ -150,4 +150,4 @@
         ...
 
     x: MyClass[int, str]
-    reveal_type(bind_result(test)(x))  # N: Revealed type is 'main.MyClass[builtins.float, builtins.str]'
+    reveal_type(bind_result(test)(x))  # N: Revealed type is "main.MyClass[builtins.float, builtins.str]"

--- a/typesafety/test_pointfree/test_compose_result.yml
+++ b/typesafety/test_pointfree/test_compose_result.yml
@@ -9,7 +9,7 @@
         ...
 
     x: IOResult[str, int]
-    reveal_type(compose_result(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.float, builtins.int]'
+    reveal_type(compose_result(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.float, builtins.int]"
 
 
 - case: compose_result_requires_context_ioresult
@@ -23,7 +23,7 @@
         ...
 
     x: RequiresContextIOResult[str, bool, float]
-    reveal_type(compose_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool, builtins.float]'
+    reveal_type(compose_result(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.bool, builtins.float]"
 
 
 - case: compose_result_future
@@ -37,7 +37,7 @@
         ...
 
     x: FutureResult[str, float]
-    reveal_type(compose_result(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.str, builtins.float]'
+    reveal_type(compose_result(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.str, builtins.float]"
 
 
 - case: compose_result_requires_context_future_result
@@ -51,7 +51,7 @@
         ...
 
     x: RequiresContextFutureResult[str, float, NoDeps]
-    reveal_type(compose_result(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str, builtins.float, Any]'
+    reveal_type(compose_result(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.str, builtins.float, Any]"
 
 
 - case: compose_result_custom_type
@@ -77,4 +77,4 @@
         ...
 
     x: MyClass[str, float]
-    reveal_type(compose_result(test)(x))  # N: Revealed type is 'main.MyClass[builtins.bool, builtins.float]'
+    reveal_type(compose_result(test)(x))  # N: Revealed type is "main.MyClass[builtins.bool, builtins.float]"

--- a/typesafety/test_pointfree/test_cond.yml
+++ b/typesafety/test_pointfree/test_cond.yml
@@ -4,7 +4,7 @@
     from returns.pointfree import cond
     from returns.result import Result
 
-    reveal_type(cond(Result, 42, '42')(True))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(cond(Result, 42, '42')(True))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: cond_ioresult
@@ -13,7 +13,7 @@
     from returns.io import IOResult
     from returns.pointfree import cond
 
-    reveal_type(cond(IOResult, 'success', 'failure')(False))  # N: Revealed type is 'returns.io.IOResult[builtins.str, builtins.str]'
+    reveal_type(cond(IOResult, 'success', 'failure')(False))  # N: Revealed type is "returns.io.IOResult[builtins.str, builtins.str]"
 
 
 - case: cond_future_result
@@ -22,7 +22,7 @@
     from returns.future import FutureResult
     from returns.pointfree import cond
 
-    reveal_type(cond(FutureResult, True, False)(False))  # N: Revealed type is 'returns.future.FutureResult[builtins.bool, builtins.bool]'
+    reveal_type(cond(FutureResult, True, False)(False))  # N: Revealed type is "returns.future.FutureResult[builtins.bool, builtins.bool]"
 
 
 - case: cond_reader_ioresult
@@ -31,7 +31,7 @@
     from returns.pointfree import cond
     from returns.context import ReaderIOResult
 
-    reveal_type(cond(ReaderIOResult, 1.0, False)(True))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bool, Any]'
+    reveal_type(cond(ReaderIOResult, 1.0, False)(True))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bool, Any]"
 
 
 - case: cond_reader_future_result
@@ -40,7 +40,7 @@
     from returns.pointfree import cond
     from returns.context import ReaderFutureResult
 
-    reveal_type(cond(ReaderFutureResult, 1, 1.0)(True))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.float, Any]'
+    reveal_type(cond(ReaderFutureResult, 1, 1.0)(True))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.float, Any]"
 
 
 - case: cond_maybe
@@ -49,7 +49,7 @@
     from returns.pointfree import cond
     from returns.maybe import Maybe
 
-    reveal_type(cond(Maybe, True)(False))  # N: Revealed type is 'returns.maybe.Maybe[builtins.bool]'
+    reveal_type(cond(Maybe, True)(False))  # N: Revealed type is "returns.maybe.Maybe[builtins.bool]"
 
 
 - case: cond_custom_type
@@ -73,4 +73,4 @@
     reveal_type(cond(MyOwn, 'test', 1.0)(True))
   out: |
     main:16: error: Only concrete class can be given where "Type[MyOwn[Any, Any]]" is expected
-    main:16: note: Revealed type is 'main.MyOwn[builtins.str, builtins.float]'
+    main:16: note: Revealed type is "main.MyOwn[builtins.str, builtins.float]"

--- a/typesafety/test_pointfree/test_map.yml
+++ b/typesafety/test_pointfree/test_map.yml
@@ -13,7 +13,7 @@
     def test(a: A) -> C:
         ...
 
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.maybe.Maybe[main.C]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.maybe.Maybe[main.C]"
 
 
 - case: map_callback_protocol
@@ -41,7 +41,7 @@
     def test(arg: int) -> float:
         return arg + 1.5
 
-    reveal_type(ensure_callback(map_(test), Maybe.from_value(1)))  # N: Revealed type is 'returns.maybe.Maybe[builtins.float]'
+    reveal_type(ensure_callback(map_(test), Maybe.from_value(1)))  # N: Revealed type is "returns.maybe.Maybe[builtins.float]"
 
 
 - case: map_and_flow
@@ -59,7 +59,7 @@
         ...
 
     r: Result[int, str]
-    reveal_type(flow(r, map_(test), map_(stringify), identity))  # N: Revealed type is 'returns.result.Result*[builtins.str, builtins.str]'
+    reveal_type(flow(r, map_(test), map_(stringify), identity))  # N: Revealed type is "returns.result.Result*[builtins.str, builtins.str]"
 
 
 - case: map_and_bind
@@ -72,7 +72,7 @@
     def test(arg: int) -> Result[float, str]:
         ...
 
-    reveal_type(map_(bind(test))(IO(Success(1))))  # N: Revealed type is 'returns.io.IO[returns.result.Result[builtins.float, builtins.str]]'
+    reveal_type(map_(bind(test))(IO(Success(1))))  # N: Revealed type is "returns.io.IO[returns.result.Result[builtins.float, builtins.str]]"
 
 
 - case: map_io
@@ -84,7 +84,7 @@
     def test(arg: float) -> int:
         ...
 
-    reveal_type(map_(test)(IO(1.5)))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(map_(test)(IO(1.5)))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 
 - case: map_maybe
@@ -96,7 +96,7 @@
     def test(arg: float) -> int:
         ...
 
-    reveal_type(map_(test)(Maybe.from_value(1.5)))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int]'
+    reveal_type(map_(test)(Maybe.from_value(1.5)))  # N: Revealed type is "returns.maybe.Maybe[builtins.int]"
 
 
 - case: map_result
@@ -109,7 +109,7 @@
         ...
 
     x: Result[float, str]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: map_ioresult
@@ -122,7 +122,7 @@
         ...
 
     x: IOResult[float, str]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: map_requires_context
@@ -135,7 +135,7 @@
         ...
 
     x: RequiresContext[float, str]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.int, builtins.str]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.int, builtins.str]"
 
 
 - case: map_requires_context_result
@@ -148,7 +148,7 @@
         ...
 
     x: RequiresContextResult[float, str, bool]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: map_requires_context_ioresult
@@ -161,7 +161,7 @@
         ...
 
     x: RequiresContextIOResult[float, str, bool]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: map_requires_context_future_result
@@ -174,7 +174,7 @@
         ...
 
     x: RequiresContextFutureResult[float, str, bool]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: map_future
@@ -186,7 +186,7 @@
     def test(arg: float) -> int:
         ...
 
-    reveal_type(map_(test)(Future.from_value(1.5)))  # N: Revealed type is 'returns.future.Future[builtins.int]'
+    reveal_type(map_(test)(Future.from_value(1.5)))  # N: Revealed type is "returns.future.Future[builtins.int]"
 
 
 - case: map_future_result
@@ -199,7 +199,7 @@
         ...
 
     x: FutureResult[float, str]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: map_custom_type
@@ -223,4 +223,4 @@
         ...
 
     x: MyOwn[float]
-    reveal_type(map_(test)(x))  # N: Revealed type is 'main.MyOwn[builtins.int]'
+    reveal_type(map_(test)(x))  # N: Revealed type is "main.MyOwn[builtins.int]"

--- a/typesafety/test_pointfree/test_modify_env2.yml
+++ b/typesafety/test_pointfree/test_modify_env2.yml
@@ -37,7 +37,7 @@
         ...
 
     r: RequiresContext[int, int]
-    reveal_type(flow(r, modify_env2(modify), bind(test)))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.float, builtins.str]'
+    reveal_type(flow(r, modify_env2(modify), bind(test)))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.float, builtins.str]"
 
 
 - case: modify_env2_requires_context
@@ -47,7 +47,7 @@
     from returns.context import RequiresContext
 
     x: RequiresContext[float, int]
-    reveal_type(modify_env2(int)(x))  # N: Revealed type is 'returns.context.requires_context.RequiresContext[builtins.float, Union[builtins.str, typing.SupportsInt, builtins._SupportsIndex, builtins._SupportsTrunc]]'
+    reveal_type(modify_env2(int)(x))  # N: Revealed type is "returns.context.requires_context.RequiresContext[builtins.float, Union[builtins.str, builtins.bytes, typing.SupportsInt, typing_extensions.SupportsIndex, builtins._SupportsTrunc]]"
 
 
 - case: modify_env2_custom_type
@@ -68,4 +68,4 @@
         ...
 
     x: MyClass[float, int]
-    reveal_type(modify_env2(int)(x))  # N: Revealed type is 'main.MyClass[builtins.float, Union[builtins.str, typing.SupportsInt, builtins._SupportsIndex, builtins._SupportsTrunc]]'
+    reveal_type(modify_env2(int)(x))  # N: Revealed type is "main.MyClass[builtins.float, Union[builtins.str, builtins.bytes, typing.SupportsInt, typing_extensions.SupportsIndex, builtins._SupportsTrunc]]"

--- a/typesafety/test_pointfree/test_modify_env3.yml
+++ b/typesafety/test_pointfree/test_modify_env3.yml
@@ -38,7 +38,7 @@
         ...
 
     x: RequiresContextResult[float, Exception, int]
-    reveal_type(modify_env3(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.Exception, builtins.str]'
+    reveal_type(modify_env3(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.Exception, builtins.str]"
 
 
 - case: modify_env_and_flow
@@ -55,7 +55,7 @@
         ...
 
     r: RequiresContextResult[int, Exception, int]
-    reveal_type(flow(r, modify_env(modify), bind(test)))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.Exception, builtins.str]'
+    reveal_type(flow(r, modify_env(modify), bind(test)))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.Exception, builtins.str]"
 
 
 - case: modify_env_requires_context_result
@@ -68,7 +68,7 @@
         ...
 
     x: RequiresContextResult[float, Exception, int]
-    reveal_type(modify_env(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.Exception, builtins.str]'
+    reveal_type(modify_env(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.Exception, builtins.str]"
 
 
 - case: modify_env_requires_context_ioresult
@@ -81,7 +81,7 @@
         ...
 
     x: RequiresContextIOResult[float, Exception, int]
-    reveal_type(modify_env(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.Exception, builtins.str]'
+    reveal_type(modify_env(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.Exception, builtins.str]"
 
 
 - case: modify_env_requires_context_future_result
@@ -94,7 +94,7 @@
         ...
 
     x: RequiresContextFutureResult[float, Exception, int]
-    reveal_type(modify_env(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.Exception, builtins.str]'
+    reveal_type(modify_env(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.Exception, builtins.str]"
 
 
 - case: modify_env_custom_type
@@ -119,4 +119,4 @@
         ...
 
     x: MyClass[int, Exception, int]
-    reveal_type(modify_env(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.Exception, builtins.str]'
+    reveal_type(modify_env(test)(x))  # N: Revealed type is "main.MyClass[builtins.int, builtins.Exception, builtins.str]"

--- a/typesafety/test_pointfree/test_rescue.yml
+++ b/typesafety/test_pointfree/test_rescue.yml
@@ -34,7 +34,7 @@
         ...
 
     x: Maybe[int]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'returns.maybe.Maybe[builtins.int]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "returns.maybe.Maybe[builtins.int]"
 
 
 - case: lash_result
@@ -47,7 +47,7 @@
         ...
 
     x: Result[int, float]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: lash_ioresult
@@ -60,7 +60,7 @@
         ...
 
     x: IOResult[int, float]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: lash_context_result
@@ -73,7 +73,7 @@
         ...
 
     x: RequiresContextResult[float, float, int]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.str, builtins.int]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "returns.context.requires_context_result.RequiresContextResult[builtins.float, builtins.str, builtins.int]"
 
 
 - case: lash_context_ioresult
@@ -86,7 +86,7 @@
         ...
 
     x: RequiresContextIOResult[float, float, int]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.str, builtins.int]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.str, builtins.int]"
 
 
 - case: lash_context_future_result
@@ -99,7 +99,7 @@
         ...
 
     x: RequiresContextFutureResult[float, float, int]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.str, builtins.int]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.float, builtins.str, builtins.int]"
 
 
 - case: lash_future_result
@@ -112,7 +112,7 @@
         ...
 
     x: FutureResult[int, float]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.int, builtins.str]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.int, builtins.str]"
 
 
 - case: lash_custom_type
@@ -133,4 +133,4 @@
         ...
 
     x: MyClass[int, str]
-    reveal_type(lash(test)(x))  # N: Revealed type is 'main.MyClass[builtins.int, builtins.int]'
+    reveal_type(lash(test)(x))  # N: Revealed type is "main.MyClass[builtins.int, builtins.int]"

--- a/typesafety/test_pointfree/test_unify.yml
+++ b/typesafety/test_pointfree/test_unify.yml
@@ -8,7 +8,7 @@
         ...
 
     x: Result[str, AssertionError]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.result.Result[builtins.str, Union[builtins.AssertionError, builtins.int]]'
+    reveal_type(unify(test)(x))  # N: Revealed type is "returns.result.Result[builtins.str, Union[builtins.AssertionError, builtins.int]]"
 
 
 - case: unify_ioresult
@@ -21,7 +21,7 @@
         ...
 
     x: IOResult[float, bool]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.io.IOResult[builtins.str, Union[builtins.bool, builtins.bytes]]'
+    reveal_type(unify(test)(x))  # N: Revealed type is "returns.io.IOResult[builtins.str, Union[builtins.bool, builtins.bytes]]"
 
 
 - case: unify_future_result
@@ -34,7 +34,7 @@
         ...
 
     x: FutureResult[bool, float]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.future.FutureResult[builtins.bool, Union[builtins.float, builtins.str]]'
+    reveal_type(unify(test)(x))  # N: Revealed type is "returns.future.FutureResult[builtins.bool, Union[builtins.float, builtins.str]]"
 
 
 - case: unify_reader_ioresult
@@ -47,7 +47,7 @@
         ...
 
     x: ReaderIOResult[float, Exception, float]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool, Union[builtins.Exception, builtins.str], builtins.float]'
+    reveal_type(unify(test)(x))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.bool, Union[builtins.Exception, builtins.str], builtins.float]"
 
 
 - case: unify_reader_future_result1
@@ -60,7 +60,7 @@
         ...
 
     x: ReaderFutureResult[int, str, NoDeps]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str, builtins.bool], builtins.bool]'
+    reveal_type(unify(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str, builtins.bool], builtins.bool]"
 
 
 - case: unify_reader_future_result2
@@ -73,7 +73,7 @@
         ...
 
     x: ReaderFutureResult[int, str, float]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str, builtins.bool], builtins.float]'
+    reveal_type(unify(test)(x))  # N: Revealed type is "returns.context.requires_context_future_result.RequiresContextFutureResult[builtins.int, Union[builtins.str, builtins.bool], builtins.float]"
 
 
 - case: unify_custom_type
@@ -98,4 +98,4 @@
         ...
 
     x: MyOwn[str, ValueError]
-    reveal_type(unify(test)(x))  # N: Revealed type is 'main.MyOwn[builtins.str, Union[builtins.ValueError, builtins.bool]]'
+    reveal_type(unify(test)(x))  # N: Revealed type is "main.MyOwn[builtins.str, Union[builtins.ValueError, builtins.bool]]"

--- a/typesafety/test_primitives/test_hkt/test_dekind/test_dekind.yml
+++ b/typesafety/test_primitives/test_hkt/test_dekind/test_dekind.yml
@@ -5,7 +5,7 @@
     from returns.primitives.hkt import Kind1, dekind
 
     container: Kind1[IO, int]
-    reveal_type(dekind(container))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(dekind(container))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 
 - case: dekind_bindable
@@ -23,7 +23,7 @@
         function: Callable[[T], Kind1[Bindable1, N]],
     ) -> Bindable1[N]:
         x = dekind(instance.bind(function))
-        reveal_type(x)  # N: Revealed type is 'returns.interfaces.bindable.BindableN[N`-2, <nothing>, <nothing>]'
+        reveal_type(x)  # N: Revealed type is "returns.interfaces.bindable.BindableN[N`-2, <nothing>, <nothing>]"
         return x
 
 
@@ -34,7 +34,7 @@
     from returns.primitives.hkt import Kind2, dekind
 
     container: Kind2[IOResult, int, str]
-    reveal_type(dekind(container))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(dekind(container))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: dekind_correct_typevar
@@ -53,7 +53,7 @@
                 'IO', Callable[[_ValueType], _NewValueType],
             ],
         ):
-            reveal_type(dekind(container))  # N: Revealed type is 'main.IO[def (_ValueType`1) -> _NewValueType`-1]'
+            reveal_type(dekind(container))  # N: Revealed type is "main.IO[def (_ValueType`1) -> _NewValueType`-1]"
 
 
 - case: dekind_wrong_non_instance
@@ -69,4 +69,4 @@
         reveal_type(dekind(container))
   out: |
     main:8: error: dekind must be used with Instance as the first type argument
-    main:8: note: Revealed type is 'Any'
+    main:8: note: Revealed type is "Any"

--- a/typesafety/test_primitives/test_hkt/test_kinded/test_kinded.yml
+++ b/typesafety/test_primitives/test_hkt/test_kinded/test_kinded.yml
@@ -14,7 +14,7 @@
         ...
 
     container: Any
-    reveal_type(test(container))  # N: Revealed type is 'Any'
+    reveal_type(test(container))  # N: Revealed type is "Any"
 
 
 - case: kinded_with_kind1
@@ -32,7 +32,7 @@
         ...
 
     container: IO[str]
-    reveal_type(test(container))  # N: Revealed type is 'returns.io.IO[builtins.str]'
+    reveal_type(test(container))  # N: Revealed type is "returns.io.IO[builtins.str]"
 
 
 - case: kinded_with_kind2
@@ -51,7 +51,7 @@
         ...
 
     container: IOResult[int, str]
-    reveal_type(test(container))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(test(container))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: kinded_with_kind3
@@ -71,7 +71,7 @@
         ...
 
     container: ReaderIOResult[int, str, bool]
-    reveal_type(test(container))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(test(container))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"
 
 
 - case: kinded_regression521
@@ -93,7 +93,7 @@
         ...
 
     container: Iterable[ReaderIOResult[int, str, bool]]
-    reveal_type(test(container))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[typing.Sequence[builtins.int], builtins.str, builtins.bool]'
+    reveal_type(test(container))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[typing.Sequence[builtins.int], builtins.str, builtins.bool]"
 
 
 - case: kinded_with_container1
@@ -113,7 +113,7 @@
         ...
 
     container: IO[int]
-    reveal_type(test(container))  # N: Revealed type is 'returns.io.IO[builtins.int]'
+    reveal_type(test(container))  # N: Revealed type is "returns.io.IO[builtins.int]"
 
 
 - case: kinded_with_container2
@@ -133,7 +133,7 @@
         ...
 
     container: IOResult[int, str]
-    reveal_type(test(container))  # N: Revealed type is 'returns.io.IOResult[builtins.int, builtins.str]'
+    reveal_type(test(container))  # N: Revealed type is "returns.io.IOResult[builtins.int, builtins.str]"
 
 
 - case: kinded_with_container3
@@ -153,4 +153,4 @@
         ...
 
     container: ReaderIOResult[int, str, bool]
-    reveal_type(test(container))  # N: Revealed type is 'returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]'
+    reveal_type(test(container))  # N: Revealed type is "returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]"

--- a/typesafety/test_primitives/test_hkt/test_kinded/test_kinded_methods.yml
+++ b/typesafety/test_primitives/test_hkt/test_kinded/test_kinded_methods.yml
@@ -17,7 +17,7 @@
             ...
 
     x: Mappable[int]
-    reveal_type(x.map(str))  # N: Revealed type is 'main.Mappable[builtins.str]'
+    reveal_type(x.map(str))  # N: Revealed type is "main.Mappable[builtins.str]"
 
 
 - case: kinded_with_unannotated_self_method
@@ -39,7 +39,7 @@
             ...
 
     x: Mappable[int]
-    reveal_type(x.map(str))  # N: Revealed type is 'Any'
+    reveal_type(x.map(str))  # N: Revealed type is "Any"
 
 
 - case: kinded_with_two_params
@@ -66,7 +66,7 @@
 
     x: Mappable
     y: My[int]
-    reveal_type(x.map(y, str))  # N: Revealed type is 'main.My[builtins.str]'
+    reveal_type(x.map(y, str))  # N: Revealed type is "main.My[builtins.str]"
 
 
 - case: kinded_classmethod_with_two_params1
@@ -93,9 +93,9 @@
         ...
 
     y: My[int]
-    reveal_type(Mappable.map(y, str))  # N: Revealed type is 'main.My[builtins.str]'
-    reveal_type(My.map(y, str))  # N: Revealed type is 'main.My[builtins.str]'
-    reveal_type(y.map(y, str))  # N: Revealed type is 'main.My[builtins.str]'
+    reveal_type(Mappable.map(y, str))  # N: Revealed type is "main.My[builtins.str]"
+    reveal_type(My.map(y, str))  # N: Revealed type is "main.My[builtins.str]"
+    reveal_type(y.map(y, str))  # N: Revealed type is "main.My[builtins.str]"
 
 
 - case: kinded_classmethod_with_two_params2
@@ -122,9 +122,9 @@
         ...
 
     y: My[int]
-    reveal_type(Mappable.map(y, str))  # N: Revealed type is 'main.My[builtins.str]'
-    reveal_type(My.map(y, str))  # N: Revealed type is 'main.My[builtins.str]'
-    reveal_type(y.map(y, str))  # N: Revealed type is 'main.My[builtins.str]'
+    reveal_type(Mappable.map(y, str))  # N: Revealed type is "main.My[builtins.str]"
+    reveal_type(My.map(y, str))  # N: Revealed type is "main.My[builtins.str]"
+    reveal_type(y.map(y, str))  # N: Revealed type is "main.My[builtins.str]"
 
 
 - case: kinded_with_wrong_self_type1

--- a/typesafety/test_primitives/test_hkt/test_kinded/test_kinded_nested.yml
+++ b/typesafety/test_primitives/test_hkt/test_kinded/test_kinded_nested.yml
@@ -13,7 +13,7 @@
         ...
 
     x: ReaderIOResult[int, str, bool]
-    reveal_type(test(x))  # N: Revealed type is 'typing.Sequence[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]'
+    reveal_type(test(x))  # N: Revealed type is "typing.Sequence[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]"
 
 
 - case: kinded_with_nested_kind_instance
@@ -27,7 +27,7 @@
     def test() -> Sequence[KindN[ReaderIOResult, int, str, bool]]:
         ...
 
-    reveal_type(test())  # N: Revealed type is 'typing.Sequence[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]'
+    reveal_type(test())  # N: Revealed type is "typing.Sequence[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]"
 
 
 
@@ -47,7 +47,7 @@
     ]:
         ...
 
-    reveal_type(test())  # N: Revealed type is 'typing.Sequence[def (returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]) -> returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]'
+    reveal_type(test())  # N: Revealed type is "typing.Sequence[def (returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]) -> returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]"
 
 
 - case: kinded_with_nested_kind_tuple
@@ -64,7 +64,7 @@
     ]:
         ...
 
-    reveal_type(test())  # N: Revealed type is 'Tuple[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool], returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bytes, builtins.object]]'
+    reveal_type(test())  # N: Revealed type is "Tuple[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool], returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bytes, builtins.object]]"
 
 
 - case: kinded_with_nested_kind_union
@@ -81,7 +81,7 @@
     ]:
         ...
 
-    reveal_type(test())  # N: Revealed type is 'Union[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool], returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bytes, builtins.object]]'
+    reveal_type(test())  # N: Revealed type is "Union[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool], returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.float, builtins.bytes, builtins.object]]"
 
 
 - case: kinded_with_nested_kind_type
@@ -95,4 +95,4 @@
     def test() -> Type[KindN[ReaderIOResult, int, str, bool]]:
         ...
 
-    reveal_type(test())  # N: Revealed type is 'Type[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]'
+    reveal_type(test())  # N: Revealed type is "Type[returns.context.requires_context_ioresult.RequiresContextIOResult[builtins.int, builtins.str, builtins.bool]]"

--- a/typesafety/test_primitives/test_hkt/test_kinded/test_kinded_overload.yml
+++ b/typesafety/test_primitives/test_hkt/test_kinded/test_kinded_overload.yml
@@ -31,5 +31,5 @@
 
     test = kinded(_test)
     x: Maybe[int]
-    reveal_type(test(x))  # N: Revealed type is 'returns.maybe.Maybe[None]'
-    reveal_type(test(x, 'a'))  # N: Revealed type is 'returns.maybe.Maybe[builtins.str]'
+    reveal_type(test(x))  # N: Revealed type is "returns.maybe.Maybe[None]"
+    reveal_type(test(x, 'a'))  # N: Revealed type is "returns.maybe.Maybe[builtins.str]"

--- a/typesafety/test_primitives/test_hkt/test_kindn/test_kindn.yml
+++ b/typesafety/test_primitives/test_hkt/test_kindn/test_kindn.yml
@@ -35,5 +35,5 @@
     def test(
         arg: KindN[I, T1, T2, T3],
     ) -> KindN[I, N1, T2, T3]:
-        reveal_type(arg.map(example)) # N: Revealed type is 'returns.primitives.hkt.KindN[I`-1, N1`-2, T2`-3, T3`-4]'
+        reveal_type(arg.map(example)) # N: Revealed type is "returns.primitives.hkt.KindN[I`-1, N1`-2, T2`-3, T3`-4]"
         return arg.map(example)

--- a/typesafety/test_primitives/test_hkt/test_kindn/test_kindn_getattr.yml
+++ b/typesafety/test_primitives/test_hkt/test_kindn/test_kindn_getattr.yml
@@ -5,7 +5,7 @@
     from typing import List
 
     container: Kind1[List, int]
-    reveal_type(container.pop)  # N: Revealed type is 'def (builtins.int =) -> builtins.int*'
+    reveal_type(container.pop)  # N: Revealed type is "def (builtins.int =) -> builtins.int*"
 
 
 - case: kind_missing_getattr
@@ -25,4 +25,4 @@
     from typing import Any
 
     container: Kind1[Any, int]
-    reveal_type(container.missing)  # N: Revealed type is 'Any'
+    reveal_type(container.missing)  # N: Revealed type is "Any"

--- a/typesafety/test_primitives/test_hkt/test_supports_kind.yml
+++ b/typesafety/test_primitives/test_hkt/test_supports_kind.yml
@@ -34,6 +34,6 @@
     reveal_type(container.existing)
     reveal_type(container.missing)
   out: |
-    main:10: note: Revealed type is 'builtins.int*'
+    main:10: note: Revealed type is "builtins.int*"
     main:11: error: "Custom[int]" has no attribute "missing"
-    main:11: note: Revealed type is 'Any'
+    main:11: note: Revealed type is "Any"

--- a/typesafety/test_primitives/test_reawaitable/test_reawaitable_decorator.yml
+++ b/typesafety/test_primitives/test_reawaitable/test_reawaitable_decorator.yml
@@ -8,4 +8,4 @@
     async def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         ...
 
-    reveal_type(test)  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> typing.Coroutine[Any, Any, builtins.int]'
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> typing.Coroutine[Any, Any, builtins.int]"

--- a/typesafety/test_primitives/test_tracing/test_collect_traces.yml
+++ b/typesafety/test_primitives/test_tracing/test_collect_traces.yml
@@ -3,14 +3,14 @@
   main: |
     from returns.primitives.tracing import collect_traces
 
-    reveal_type(collect_traces)  # N: Revealed type is 'Overload(def () -> typing.ContextManager[None], def [_FunctionType <: def (*Any, **Any) -> Any] (function: _FunctionType`-1) -> _FunctionType`-1)'
+    reveal_type(collect_traces)  # N: Revealed type is "Overload(def () -> typing.ContextManager[None], def [_FunctionType <: def (*Any, **Any) -> Any] (function: _FunctionType`-1) -> _FunctionType`-1)"
 
 - case: collect_traces_context_manager_return_type_two
   disable_cache: false
   main: |
     from returns.primitives.tracing import collect_traces
 
-    with reveal_type(collect_traces()):  # N: Revealed type is 'typing.ContextManager[None]'
+    with reveal_type(collect_traces()):  # N: Revealed type is "typing.ContextManager[None]"
         pass
 
 - case: collect_traces_decorated_function_return_type
@@ -22,7 +22,7 @@
     def function() -> int:
       return 0
 
-    reveal_type(function)  # N: Revealed type is 'def () -> builtins.int'
+    reveal_type(function)  # N: Revealed type is "def () -> builtins.int"
 
 - case: collect_traces_decorated_function_with_argument_return_type
   disable_cache: false
@@ -33,4 +33,4 @@
     def function(number: int) -> str:
       return str(number)
 
-    reveal_type(function)  # N: Revealed type is 'def (number: builtins.int) -> builtins.str'
+    reveal_type(function)  # N: Revealed type is "def (number: builtins.int) -> builtins.str"

--- a/typesafety/test_result/test_construct_failure.yml
+++ b/typesafety/test_result/test_construct_failure.yml
@@ -7,7 +7,7 @@
         ...
 
     first: Result[str, int] = Failure(1)
-    reveal_type(first.lash(returns_result))  # N: Revealed type is 'returns.result.Result[builtins.str, builtins.Exception*]'
+    reveal_type(first.lash(returns_result))  # N: Revealed type is "returns.result.Result[builtins.str, builtins.Exception*]"
 
 
 - case: failure_alt
@@ -15,7 +15,7 @@
   main: |
     from returns.result import Failure
 
-    reveal_type(Failure(1).alt(str))  # N: Revealed type is 'returns.result.Result[Any, builtins.str*]'
+    reveal_type(Failure(1).alt(str))  # N: Revealed type is "returns.result.Result[Any, builtins.str*]"
 
 
 - case: failure_failure
@@ -23,4 +23,4 @@
   main: |
     from returns.result import Failure
 
-    reveal_type(Failure(1).failure())  # N: Revealed type is 'builtins.int*'
+    reveal_type(Failure(1).failure())  # N: Revealed type is "builtins.int*"

--- a/typesafety/test_result/test_construct_success.yml
+++ b/typesafety/test_result/test_construct_success.yml
@@ -7,7 +7,7 @@
         ...
 
     first: Result[int, Exception] = Success(1)
-    reveal_type(first.bind(returns_result))  # N: Revealed type is 'returns.result.Result[builtins.str*, builtins.Exception]'
+    reveal_type(first.bind(returns_result))  # N: Revealed type is "returns.result.Result[builtins.str*, builtins.Exception]"
 
 
 - case: success_bind_result
@@ -19,7 +19,7 @@
         ...
 
     first: Result[int, Exception] = Success(1)
-    reveal_type(first.bind_result(returns_result))  # N: Revealed type is 'returns.result.Result[builtins.str*, builtins.Exception]'
+    reveal_type(first.bind_result(returns_result))  # N: Revealed type is "returns.result.Result[builtins.str*, builtins.Exception]"
 
 
 - case: success_map
@@ -27,7 +27,7 @@
   main: |
     from returns.result import Success, Result
 
-    reveal_type(Success(1).map(str))  # N: Revealed type is 'returns.result.Result[builtins.str*, Any]'
+    reveal_type(Success(1).map(str))  # N: Revealed type is "returns.result.Result[builtins.str*, Any]"
 
 
 - case: success_apply1
@@ -35,7 +35,7 @@
   main: |
     from returns.result import Success, Result
 
-    reveal_type(Success(1).apply(Success(str)))  # N: Revealed type is 'returns.result.Result[builtins.str*, Any]'
+    reveal_type(Success(1).apply(Success(str)))  # N: Revealed type is "returns.result.Result[builtins.str*, Any]"
 
 
 - case: success_apply2
@@ -48,7 +48,7 @@
     def sum_two(first: int, second: float) -> str:
         ...
 
-    reveal_type(Success(2.0).apply(Success(1).apply(Success(sum_two))))  # N: Revealed type is 'returns.result.Result[builtins.str*, Any]'
+    reveal_type(Success(2.0).apply(Success(1).apply(Success(sum_two))))  # N: Revealed type is "returns.result.Result[builtins.str*, Any]"
 
 
 - case: success_value_or
@@ -56,7 +56,7 @@
   main: |
     from returns.result import Success
 
-    reveal_type(Success(1).value_or(None))  # N: Revealed type is 'Union[builtins.int, None]'
+    reveal_type(Success(1).value_or(None))  # N: Revealed type is "Union[builtins.int, None]"
 
 
 - case: success_unwrap
@@ -64,4 +64,4 @@
   main: |
     from returns.result import Success
 
-    reveal_type(Success(1).unwrap())  # N: Revealed type is 'builtins.int*'
+    reveal_type(Success(1).unwrap())  # N: Revealed type is "builtins.int*"

--- a/typesafety/test_result/test_result_error.yml
+++ b/typesafety/test_result/test_result_error.yml
@@ -8,4 +8,4 @@
             return Success(arg)
         return Failure(ValueError('test'))
 
-    reveal_type(some(1))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(some(1))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.Exception]"

--- a/typesafety/test_result/test_result_type_cast.yml
+++ b/typesafety/test_result/test_result_type_cast.yml
@@ -4,7 +4,7 @@
     from returns.result import Result, Success
 
     first: Result[int, Exception] = Success(1)
-    reveal_type(first)  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: result_success_cast2
@@ -13,7 +13,7 @@
     from returns.result import Result, Success
 
     first: Result[object, Exception] = Success(1)
-    reveal_type(first)  # N: Revealed type is 'returns.result.Result[builtins.object, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.result.Result[builtins.object, builtins.Exception]"
 
 
 - case: result_failure_cast1
@@ -22,7 +22,7 @@
     from returns.result import Result, Failure
 
     first: Result[int, Exception] = Failure(Exception())
-    reveal_type(first)  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: result_failure_cast2
@@ -31,7 +31,7 @@
     from returns.result import Result, Failure
 
     first: Result[int, Exception] = Failure(TypeError())
-    reveal_type(first)  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(first)  # N: Revealed type is "returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: result_swap
@@ -40,7 +40,7 @@
     from returns.result import Result
 
     x: Result[int, str]
-    reveal_type(x.swap())  # N: Revealed type is 'returns.result.Result[builtins.str*, builtins.int*]'
+    reveal_type(x.swap())  # N: Revealed type is "returns.result.Result[builtins.str*, builtins.int*]"
 
 
 - case: result_getattr
@@ -57,7 +57,7 @@
   main: |
     from returns.result import Result
 
-    reveal_type(Result.from_value(1))  # N: Revealed type is 'returns.result.Result[builtins.int*, Any]'
+    reveal_type(Result.from_value(1))  # N: Revealed type is "returns.result.Result[builtins.int*, Any]"
 
 
 - case: result_from_failure
@@ -65,7 +65,7 @@
   main: |
     from returns.result import Result
 
-    reveal_type(Result.from_failure(1))  # N: Revealed type is 'returns.result.Result[Any, builtins.int*]'
+    reveal_type(Result.from_failure(1))  # N: Revealed type is "returns.result.Result[Any, builtins.int*]"
 
 
 - case: result_from_result
@@ -74,7 +74,7 @@
     from returns.result import Result
 
     x: Result[int ,str]
-    reveal_type(Result.from_result(x))  # N: Revealed type is 'returns.result.Result[builtins.int*, builtins.str*]'
+    reveal_type(Result.from_result(x))  # N: Revealed type is "returns.result.Result[builtins.int*, builtins.str*]"
 
 
 - case: result_covariant_cast
@@ -84,7 +84,7 @@
 
     first: Result[TypeError, ValueError]  # we cast both values
     second: Result[Exception, Exception] = first
-    reveal_type(second)  # N: Revealed type is 'returns.result.Result[builtins.Exception, builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.result.Result[builtins.Exception, builtins.Exception]"
 
 
 - case: result_success_bind_contra1
@@ -96,7 +96,7 @@
       ...
 
     first: Result[int, str] = Success(4)
-    reveal_type(first.bind(test))  # N: Revealed type is 'returns.result.Result[builtins.float*, builtins.str]'
+    reveal_type(first.bind(test))  # N: Revealed type is "returns.result.Result[builtins.float*, builtins.str]"
 
 
 - case: result_success_bind_contra2
@@ -109,7 +109,7 @@
 
     first: Result[int, Exception]
     second = first.bind(test)
-    reveal_type(second)  # N: Revealed type is 'returns.result.Result[builtins.int*, builtins.Exception]'
+    reveal_type(second)  # N: Revealed type is "returns.result.Result[builtins.int*, builtins.Exception]"
 
 
 - case: result_correct_usage
@@ -122,7 +122,7 @@
             return Success(inner_value * 2)
         return Failure(str(inner_value))
 
-    reveal_type(factory(1))  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.str]'
+    reveal_type(factory(1))  # N: Revealed type is "returns.result.Result[builtins.int, builtins.str]"
 
 
 - case: result_success_type
@@ -130,7 +130,7 @@
   main: |
     from returns.result import Result
 
-    reveal_type(Result.success_type)  # N: Revealed type is 'Type[returns.result._Success[Any]]'
+    reveal_type(Result.success_type)  # N: Revealed type is "Type[returns.result._Success[Any]]"
 
 
 - case: result_failure_type
@@ -138,7 +138,7 @@
   main: |
     from returns.result import Result
 
-    reveal_type(Result.failure_type)  # N: Revealed type is 'Type[returns.result._Failure[Any]]'
+    reveal_type(Result.failure_type)  # N: Revealed type is "Type[returns.result._Failure[Any]]"
 
 
 - case: resulte_typecast1
@@ -152,7 +152,7 @@
         return Failure(ValueError(arg))
 
     result: Result[int, Exception] = function(1)
-    reveal_type(result)  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(result)  # N: Revealed type is "returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: resulte_typecast2
@@ -166,4 +166,4 @@
         return Failure(ValueError(arg))
 
     result: ResultE[int] = function(1)
-    reveal_type(result)  # N: Revealed type is 'returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(result)  # N: Revealed type is "returns.result.Result[builtins.int, builtins.Exception]"

--- a/typesafety/test_result/test_safe.yml
+++ b/typesafety/test_result/test_safe.yml
@@ -7,7 +7,7 @@
     def test() -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def () -> returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(test)  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: safe_composition_no_params
@@ -18,7 +18,7 @@
     def test() -> int:
         return 1
 
-    reveal_type(safe(test))  # N: Revealed type is 'def () -> returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(safe(test))  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: safe_decorator_with_args
@@ -31,7 +31,7 @@
     def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: safe_composition_with_args
@@ -43,7 +43,7 @@
     def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         return 1
 
-    reveal_type(safe(test))  # N: Revealed type is 'def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(safe(test))  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: safe_regression333
@@ -56,7 +56,7 @@
     def send(text: str) -> Any:
         return "test"
 
-    reveal_type(send)  # N: Revealed type is 'def (text: builtins.str) -> returns.result.Result[Any, builtins.Exception]'
+    reveal_type(send)  # N: Revealed type is "def (text: builtins.str) -> returns.result.Result[Any, builtins.Exception]"
 
 
 - case: safe_regression641
@@ -69,7 +69,7 @@
         def raise_for_status(self) -> None:
             ...
 
-    reveal_type(safe(tap(Response.raise_for_status)))  # N: Revealed type is 'def (main.Response*) -> returns.result.Result[main.Response, builtins.Exception]'
+    reveal_type(safe(tap(Response.raise_for_status)))  # N: Revealed type is "def (main.Response*) -> returns.result.Result[main.Response, builtins.Exception]"
 
 
 - case: safe_decorator_with_args_kwargs
@@ -81,7 +81,7 @@
     def test(*args, **kwargs) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (*args: Any, **kwargs: Any) -> returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(test)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: safe_decorator_with_args_kwargs
@@ -93,7 +93,7 @@
     def test(*args: int, **kwargs: str) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (*args: builtins.int, **kwargs: builtins.str) -> returns.result.Result[builtins.int, builtins.Exception]'
+    reveal_type(test)  # N: Revealed type is "def (*args: builtins.int, **kwargs: builtins.str) -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
 - case: safe_decorator_composition
@@ -107,4 +107,4 @@
     def test(*args: int, **kwargs: str) -> int:
         return 1
 
-    reveal_type(test)  # N: Revealed type is 'def (*args: builtins.int, **kwargs: builtins.str) -> returns.io.IO[returns.result.Result*[builtins.int*, builtins.Exception]]'
+    reveal_type(test)  # N: Revealed type is "def (*args: builtins.int, **kwargs: builtins.str) -> returns.io.IO[returns.result.Result*[builtins.int*, builtins.Exception]]"

--- a/typesafety/test_unsafe/test_unsafe.yml
+++ b/typesafety/test_unsafe/test_unsafe.yml
@@ -4,4 +4,4 @@
     from returns.io import IO
     from returns.unsafe import unsafe_perform_io
 
-    reveal_type(unsafe_perform_io(IO(1)))  # N: Revealed type is 'builtins.int*'
+    reveal_type(unsafe_perform_io(IO(1)))  # N: Revealed type is "builtins.int*"


### PR DESCRIPTION
# Bumps `mypy` from `0.812` to `0.902`

Hey @sobolevn, I've fixed the typesafety tests that were failing because the new output format of `mypy` but two tests are still failing. Can you check please?

If you want to merge this PR ASAP, feel free to commit on this branch too!

Closes #972 