### PR TITLE
add missing __slots__ to containers and their base classes (#1144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Versions before `1.0.0` are `0Ver`-based:
 incremental in minor, bugfixes only are patches.
 See [0Ver](https://0ver.org/).
 
+## 0.17.1
+
+### Bugfixes
+
+- Fixes `__slots__` not being set properly in containers and their base classes
 
 ## 0.17.0
 

--- a/returns/context/requires_context.py
+++ b/returns/context/requires_context.py
@@ -77,6 +77,8 @@ class RequiresContext(
 
     """
 
+    __slots__ = ()
+
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.
     _inner_value: Callable[[RequiresContext, _EnvType], _ReturnType]
 

--- a/returns/context/requires_context_future_result.py
+++ b/returns/context/requires_context_future_result.py
@@ -95,6 +95,8 @@ class RequiresContextFutureResult(
 
     """
 
+    __slots__ = ()
+
     #: Inner value of `RequiresContext`
     #: is just a function that returns `FutureResult`.
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.

--- a/returns/context/requires_context_ioresult.py
+++ b/returns/context/requires_context_ioresult.py
@@ -102,6 +102,8 @@ class RequiresContextIOResult(
 
     """
 
+    __slots__ = ()
+
     #: Inner value of `RequiresContext`
     #: is just a function that returns `IOResult`.
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.

--- a/returns/context/requires_context_result.py
+++ b/returns/context/requires_context_result.py
@@ -93,6 +93,8 @@ class RequiresContextResult(
 
     """
 
+    __slots__ = ()
+
     #: This field has an extra 'RequiresContext' just because `mypy` needs it.
     _inner_value: Callable[
         [RequiresContextResult, _EnvType],

--- a/returns/contrib/pytest/plugin.py
+++ b/returns/contrib/pytest/plugin.py
@@ -43,7 +43,7 @@ class ReturnsAsserts(object):
 
     __slots__ = ()
 
-    @staticmethod
+    @staticmethod  # noqa: WPS602
     def assert_equal(  # noqa: WPS602
         first,
         second,
@@ -55,12 +55,12 @@ class ReturnsAsserts(object):
         from returns.primitives.asserts import assert_equal
         assert_equal(first, second, deps=deps, backend=backend)
 
-    @staticmethod
+    @staticmethod  # noqa: WPS602
     def is_error_handled(container) -> bool:  # noqa: WPS602
         """Ensures that container has its error handled in the end."""
         return id(container) in _ERRORS_HANDLED
 
-    @staticmethod
+    @staticmethod  # noqa: WPS602
     @contextmanager
     def assert_trace(  # noqa: WPS602
         trace_type: _ReturnsResultType,

--- a/returns/contrib/pytest/plugin.py
+++ b/returns/contrib/pytest/plugin.py
@@ -3,7 +3,7 @@ import sys
 from contextlib import contextmanager
 from functools import partial, wraps
 from types import FrameType
-from typing import TYPE_CHECKING, Any, Callable, Iterator, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, TypeVar, Union
 
 import pytest
 from typing_extensions import Final, final
@@ -11,7 +11,6 @@ from typing_extensions import Final, final
 if TYPE_CHECKING:
     from returns.interfaces.specific.result import ResultLikeN
 
-_ERROR_FIELD: Final = '_error_handled'
 _ERROR_HANDLERS: Final = (
     'lash',
 )
@@ -19,6 +18,17 @@ _ERRORS_COPIERS: Final = (
     'map',
     'alt',
 )
+
+# We keep track of errors handled by keeping a mapping of <object id>: object.
+# If an error is handled, it is in the mapping.
+# If it isn't in the mapping, the error is not handled.
+#
+# Note only storing object IDs would not work, as objects may be GC'ed
+# and their object id assigned to another object.
+# Also, the object itself cannot be (in) the key because
+# (1) we cannot always assume hashability and
+# (2) we need to track the object identity, not its value
+_ERRORS_HANDLED: Final[Dict[int, Any]] = {}  # noqa: WPS407
 
 _FunctionType = TypeVar('_FunctionType', bound=Callable)
 _ReturnsResultType = TypeVar(
@@ -33,8 +43,8 @@ class ReturnsAsserts(object):
 
     __slots__ = ()
 
-    def assert_equal(
-        self,
+    @staticmethod
+    def assert_equal(  # noqa: WPS602
         first,
         second,
         *,
@@ -45,13 +55,14 @@ class ReturnsAsserts(object):
         from returns.primitives.asserts import assert_equal
         assert_equal(first, second, deps=deps, backend=backend)
 
-    def is_error_handled(self, container) -> bool:
+    @staticmethod
+    def is_error_handled(container) -> bool:  # noqa: WPS602
         """Ensures that container has its error handled in the end."""
-        return bool(getattr(container, _ERROR_FIELD, False))
+        return id(container) in _ERRORS_HANDLED
 
+    @staticmethod
     @contextmanager
-    def assert_trace(
-        self,
+    def assert_trace(  # noqa: WPS602
         trace_type: _ReturnsResultType,
         function_to_search: _FunctionType,
     ) -> Iterator[None]:
@@ -76,9 +87,16 @@ class ReturnsAsserts(object):
 
 
 @pytest.fixture(scope='session')
-def returns(_patch_containers) -> ReturnsAsserts:  # noqa: WPS442
+def returns(_patch_containers) -> ReturnsAsserts:
     """Returns our own class with helpers assertions to check containers."""
     return ReturnsAsserts()
+
+
+@pytest.fixture(autouse=True)
+def _clear_errors_handled():
+    """Ensures the 'errors handled' registry doesn't leak memory."""
+    yield
+    _ERRORS_HANDLED.clear()
 
 
 def pytest_configure(config) -> None:
@@ -182,16 +200,12 @@ class _PatchedContainer(object):
         if inspect.iscoroutinefunction(original):
             async def factory(self, *args, **kwargs):
                 original_result = await original(self, *args, **kwargs)
-                object.__setattr__(
-                    original_result, _ERROR_FIELD, True,  # noqa: WPS425
-                )
+                _ERRORS_HANDLED[id(original_result)] = original_result
                 return original_result
         else:
             def factory(self, *args, **kwargs):
                 original_result = original(self, *args, **kwargs)
-                object.__setattr__(
-                    original_result, _ERROR_FIELD, True,  # noqa: WPS425
-                )
+                _ERRORS_HANDLED[id(original_result)] = original_result
                 return original_result
         return wraps(original)(factory)
 
@@ -200,20 +214,14 @@ class _PatchedContainer(object):
         if inspect.iscoroutinefunction(original):
             async def factory(self, *args, **kwargs):
                 original_result = await original(self, *args, **kwargs)
-                object.__setattr__(
-                    original_result,
-                    _ERROR_FIELD,
-                    getattr(self, _ERROR_FIELD, False),
-                )
+                if id(self) in _ERRORS_HANDLED:
+                    _ERRORS_HANDLED[id(original_result)] = original_result
                 return original_result
         else:
             def factory(self, *args, **kwargs):
                 original_result = original(self, *args, **kwargs)
-                object.__setattr__(
-                    original_result,
-                    _ERROR_FIELD,
-                    getattr(self, _ERROR_FIELD, False),
-                )
+                if id(self) in _ERRORS_HANDLED:
+                    _ERRORS_HANDLED[id(original_result)] = original_result
                 return original_result
         return wraps(original)(factory)
 

--- a/returns/future.py
+++ b/returns/future.py
@@ -85,6 +85,8 @@ class Future(
 
     """
 
+    __slots__ = ()
+
     _inner_value: Awaitable[_ValueType]
 
     def __init__(self, inner_value: Awaitable[_ValueType]) -> None:
@@ -521,6 +523,8 @@ class FutureResult(
         - https://zio.dev/docs/overview/overview_basic_concurrency
 
     """
+
+    __slots__ = ()
 
     _inner_value: Awaitable[Result[_ValueType, _ErrorType]]
 

--- a/returns/interfaces/altable.py
+++ b/returns/interfaces/altable.py
@@ -35,6 +35,8 @@ class _LawSpec(LawSpecDef):
     https://en.wikibooks.org/wiki/Haskell/The_Functor_class#The_functor_laws
     """
 
+    __slots__ = ()
+
     @law_definition
     def identity_law(
         altable: 'AltableN[_FirstType, _SecondType, _ThirdType]',
@@ -60,6 +62,8 @@ class AltableN(
     Lawful['AltableN[_FirstType, _SecondType, _ThirdType]'],
 ):
     """Modifies the second type argument with a pure function."""
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law1(_LawSpec.identity_law),

--- a/returns/interfaces/applicative.py
+++ b/returns/interfaces/applicative.py
@@ -37,6 +37,8 @@ class _LawSpec(LawSpecDef):
     Discussion: https://bit.ly/3jffz3L
     """
 
+    __slots__ = ()
+
     @law_definition
     def identity_law(
         container: 'ApplicativeN[_FirstType, _SecondType, _ThirdType]',
@@ -130,6 +132,8 @@ class ApplicativeN(
         - http://learnyouahaskell.com/functors-applicative-functors-and-monoids
 
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law1(_LawSpec.identity_law),

--- a/returns/interfaces/bimappable.py
+++ b/returns/interfaces/bimappable.py
@@ -21,6 +21,8 @@ class BiMappableN(
 
     """
 
+    __slots__ = ()
+
 
 #: Type alias for kinds with two type arguments.
 BiMappable2 = BiMappableN[_FirstType, _SecondType, NoReturn]

--- a/returns/interfaces/bindable.py
+++ b/returns/interfaces/bindable.py
@@ -23,6 +23,8 @@ class BindableN(Generic[_FirstType, _SecondType, _ThirdType]):
     works with the first type argument.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind(
         self: _BindableType,

--- a/returns/interfaces/container.py
+++ b/returns/interfaces/container.py
@@ -32,6 +32,8 @@ class _LawSpec(LawSpecDef):
     Good explanation: https://bit.ly/2Qsi5re
     """
 
+    __slots__ = ()
+
     @law_definition
     def left_identity_law(
         raw_value: _FirstType,
@@ -110,6 +112,8 @@ class ContainerN(
         - https://bit.ly/2CTEVov
 
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law3(_LawSpec.left_identity_law),

--- a/returns/interfaces/equable.py
+++ b/returns/interfaces/equable.py
@@ -24,6 +24,8 @@ class _LawSpec(LawSpecDef):
     Description: https://bit.ly/34D40iT
     """
 
+    __slots__ = ()
+
     @law_definition
     def reflexive_law(
         first: _EqualType,
@@ -61,6 +63,8 @@ class Equable(Lawful['Equable']):
     - ``Reader`` has to be called to get the value
 
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law1(_LawSpec.reflexive_law),

--- a/returns/interfaces/failable.py
+++ b/returns/interfaces/failable.py
@@ -37,6 +37,8 @@ class _FailableLawSpec(LawSpecDef):
     We need to be sure that ``.lash`` won't lash success types.
     """
 
+    __slots__ = ()
+
     @law_definition
     def lash_short_circuit_law(
         raw_value: _FirstType,
@@ -65,6 +67,8 @@ class FailableN(
     Use ``SingleFailableN`` and ``DiverseFailableN`` instead.
     """
 
+    __slots__ = ()
+
     _laws: ClassVar[Sequence[Law]] = (
         Law3(_FailableLawSpec.lash_short_circuit_law),
     )
@@ -85,6 +89,8 @@ class _SingleFailableLawSpec(LawSpecDef):
     We need to be sure that ``.map`` and ``.bind``
     works correctly for ``empty`` property.
     """
+
+    __slots__ = ()
 
     @law_definition
     def map_short_circuit_law(
@@ -133,6 +139,8 @@ class SingleFailableN(
     Like ``Maybe`` types where the only failed value is ``Nothing``.
     """
 
+    __slots__ = ()
+
     _laws: ClassVar[Sequence[Law]] = (
         Law2(_SingleFailableLawSpec.map_short_circuit_law),
         Law2(_SingleFailableLawSpec.bind_short_circuit_law),
@@ -162,6 +170,8 @@ class _DiverseFailableLawSpec(LawSpecDef):
     We need to be sure that ``.map``, ``.bind``, ``.apply`` and ``.alt``
     works correctly for both success and failure types.
     """
+
+    __slots__ = ()
 
     @law_definition
     def map_short_circuit_law(
@@ -230,6 +240,8 @@ class DiverseFailableN(
 
     Like ``Result`` types.
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law3(_DiverseFailableLawSpec.map_short_circuit_law),

--- a/returns/interfaces/lashable.py
+++ b/returns/interfaces/lashable.py
@@ -23,6 +23,8 @@ class LashableN(Generic[_FirstType, _SecondType, _ThirdType]):
     works with the second type value.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def lash(
         self: _LashableType,

--- a/returns/interfaces/mappable.py
+++ b/returns/interfaces/mappable.py
@@ -35,6 +35,8 @@ class _LawSpec(LawSpecDef):
     https://en.wikibooks.org/wiki/Haskell/The_Functor_class#The_functor_laws
     """
 
+    __slots__ = ()
+
     @law_definition
     def identity_law(
         mappable: 'MappableN[_FirstType, _SecondType, _ThirdType]',
@@ -68,6 +70,8 @@ class MappableN(
         - https://en.wikipedia.org/wiki/Functor
 
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law1(_LawSpec.identity_law),

--- a/returns/interfaces/specific/future.py
+++ b/returns/interfaces/specific/future.py
@@ -44,6 +44,8 @@ class FutureLikeN(io.IOLikeN[_FirstType, _SecondType, _ThirdType]):
     But at the time this is not a real ``Future`` and cannot be awaited.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_future(
         self: _FutureLikeType,
@@ -103,6 +105,8 @@ class AwaitableFutureN(Generic[_FirstType, _SecondType, _ThirdType]):
     Should not be used directly. Use ``FutureBasedN`` instead.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def __await__(self: _AsyncFutureType) -> Generator[
         Any, Any, io.IOLikeN[_FirstType, _SecondType, _ThirdType],
@@ -135,6 +139,8 @@ class FutureBasedN(
 
     They can be awaited.
     """
+
+    __slots__ = ()
 
 
 #: Type alias for kinds with one type argument.

--- a/returns/interfaces/specific/future_result.py
+++ b/returns/interfaces/specific/future_result.py
@@ -41,6 +41,8 @@ class FutureResultLikeN(
     It is also cannot be unwrapped, because it is not a real ``IOResult``.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_future_result(
         self: _FutureResultLikeType,
@@ -94,6 +96,8 @@ class FutureResultBasedN(
     They can be awaited.
     Still cannot be unwrapped.
     """
+
+    __slots__ = ()
 
 
 #: Type alias for kinds with two type arguments.

--- a/returns/interfaces/specific/io.py
+++ b/returns/interfaces/specific/io.py
@@ -27,6 +27,8 @@ class IOLikeN(container.ContainerN[_FirstType, _SecondType, _ThirdType]):
 
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_io(
         self: _IOLikeType,
@@ -68,6 +70,8 @@ class IOBasedN(
     While ``IOLikeN`` is different. It can be lazy and cannot be compared.
 
     """
+
+    __slots__ = ()
 
 
 #: Type alias for kinds with one type argument.

--- a/returns/interfaces/specific/ioresult.py
+++ b/returns/interfaces/specific/ioresult.py
@@ -37,6 +37,8 @@ class IOResultLikeN(
     Like ``FutureResult`` or ``RequiresContextIOResult``.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_ioresult(
         self: _IOResultLikeType,
@@ -95,6 +97,8 @@ class IOResultBasedN(
 
     Can be unwrapped.
     """
+
+    __slots__ = ()
 
 
 #: Type alias for kinds with two type arguments.

--- a/returns/interfaces/specific/maybe.py
+++ b/returns/interfaces/specific/maybe.py
@@ -48,6 +48,8 @@ class _LawSpec(LawSpecDef):
     works correctly for both successful and failed types.
     """
 
+    __slots__ = ()
+
     @law_definition
     def map_short_circuit_law(
         container: 'MaybeLikeN[_FirstType, _SecondType, _ThirdType]',
@@ -122,6 +124,8 @@ class MaybeLikeN(
     Cannot be unwrapped or compared.
     """
 
+    __slots__ = ()
+
     _laws: ClassVar[Sequence[Law]] = (
         Law2(_LawSpec.map_short_circuit_law),
         Law2(_LawSpec.bind_short_circuit_law),
@@ -163,6 +167,8 @@ class MaybeBasedN(
 
     Can be unwrapped and compared.
     """
+
+    __slots__ = ()
 
     @abstractmethod
     def or_else_call(

--- a/returns/interfaces/specific/reader.py
+++ b/returns/interfaces/specific/reader.py
@@ -82,6 +82,8 @@ class Contextable(Generic[_ValueType, _EnvType]):
     And so on.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def __call__(self, deps: _EnvType) -> _ValueType:
         """Receives one parameter, returns a value. As simple as that."""
@@ -93,6 +95,8 @@ class ReaderLike2(Container2[_FirstType, _SecondType]):
 
     It has two type arguments and treats the second type argument as env type.
     """
+
+    __slots__ = ()
 
     @property
     @abstractmethod
@@ -146,6 +150,8 @@ class CallableReader2(
     other than defining your own ``Reader`` interfaces.
     """
 
+    __slots__ = ()
+
 
 class ReaderLike3(Container3[_FirstType, _SecondType, _ThirdType]):
     """
@@ -154,6 +160,8 @@ class ReaderLike3(Container3[_FirstType, _SecondType, _ThirdType]):
     It has three type arguments and treats the third type argument as env type.
     The second type argument is not used here.
     """
+
+    __slots__ = ()
 
     @property
     @abstractmethod
@@ -207,6 +215,8 @@ class CallableReader3(
     other than defining your own ``Reader`` interfaces.
     """
 
+    __slots__ = ()
+
 
 @final
 class _LawSpec(LawSpecDef):
@@ -215,6 +225,8 @@ class _LawSpec(LawSpecDef):
 
     See: https://github.com/haskell/mtl/pull/61/files
     """
+
+    __slots__ = ()
 
     @law_definition
     def purity_law(
@@ -251,6 +263,8 @@ class ReaderBased2(
     The only thing that differs from ``ReaderLike2`` is that we know
     the specific types for its ``__call__`` method.
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law2(_LawSpec.purity_law),

--- a/returns/interfaces/specific/reader_future_result.py
+++ b/returns/interfaces/specific/reader_future_result.py
@@ -53,6 +53,8 @@ class ReaderFutureResultLikeN(
     Cannot be called.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_context_future_result(
         self: _ReaderFutureResultLikeType,
@@ -108,6 +110,8 @@ class _LawSpec(LawSpecDef):
     See: https://github.com/haskell/mtl/pull/61/files
     """
 
+    __slots__ = ()
+
     @law_definition
     def asking_law(
         container:
@@ -141,6 +145,8 @@ class ReaderFutureResultBasedN(
 
     In this case the return type of ``__call__`` is ``FutureResult``.
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law2(_LawSpec.asking_law),

--- a/returns/interfaces/specific/reader_ioresult.py
+++ b/returns/interfaces/specific/reader_ioresult.py
@@ -44,6 +44,8 @@ class ReaderIOResultLikeN(
     Cannot be called.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_context_ioresult(
         self: _ReaderIOResultLikeType,
@@ -74,6 +76,8 @@ class _LawSpec(LawSpecDef):
 
     See: https://github.com/haskell/mtl/pull/61/files
     """
+
+    __slots__ = ()
 
     @law_definition
     def asking_law(
@@ -106,6 +110,8 @@ class ReaderIOResultBasedN(
 
     In this case the return type of ``__call__`` is ``IOResult``.
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law2(_LawSpec.asking_law),

--- a/returns/interfaces/specific/reader_result.py
+++ b/returns/interfaces/specific/reader_result.py
@@ -44,6 +44,8 @@ class ReaderResultLikeN(
     Cannot be called.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_context_result(
         self: _ReaderResultLikeType,
@@ -82,6 +84,8 @@ class _LawSpec(LawSpecDef):
 
     See: https://github.com/haskell/mtl/pull/61/files
     """
+
+    __slots__ = ()
 
     @law_definition
     def purity_law(
@@ -122,6 +126,8 @@ class ReaderResultBasedN(
 
     In this case the return type of ``__call__`` is ``Result``.
     """
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law2(_LawSpec.purity_law),

--- a/returns/interfaces/specific/result.py
+++ b/returns/interfaces/specific/result.py
@@ -41,6 +41,8 @@ class ResultLikeN(
     Like ``RequiresContextResult`` or ``FutureResult``.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def bind_result(
         self: _ResultLikeType,
@@ -76,6 +78,8 @@ class UnwrappableResult(
     Use ``ResultBasedN`` and ``IOResultBasedN`` instead.
     """
 
+    __slots__ = ()
+
 
 class ResultBasedN(
     UnwrappableResult[
@@ -92,6 +96,8 @@ class ResultBasedN(
 
     Can be unwrapped.
     """
+
+    __slots__ = ()
 
 
 #: Type alias for kinds with two type arguments.

--- a/returns/interfaces/swappable.py
+++ b/returns/interfaces/swappable.py
@@ -25,6 +25,8 @@ _SwappableType = TypeVar('_SwappableType', bound='SwappableN')
 class _LawSpec(LawSpecDef):
     """Laws for :class:`~SwappableN` type."""
 
+    __slots__ = ()
+
     @law_definition
     def double_swap_law(
         container: 'SwappableN[_FirstType, _SecondType, _ThirdType]',
@@ -46,6 +48,8 @@ class SwappableN(
     Lawful['SwappableN[_FirstType, _SecondType, _ThirdType]'],
 ):
     """Interface that allows swapping first and second type values."""
+
+    __slots__ = ()
 
     _laws: ClassVar[Sequence[Law]] = (
         Law1(_LawSpec.double_swap_law),

--- a/returns/interfaces/unwrappable.py
+++ b/returns/interfaces/unwrappable.py
@@ -18,6 +18,8 @@ class Unwrappable(Generic[_FirstType, _SecondType]):
     to raise ``UnwrapFailedError`` if unwrap is not possible.
     """
 
+    __slots__ = ()
+
     @abstractmethod
     def unwrap(self: _UnwrappableType) -> _FirstType:
         """

--- a/returns/io.py
+++ b/returns/io.py
@@ -68,6 +68,8 @@ class IO(
 
     """
 
+    __slots__ = ()
+
     _inner_value: _ValueType
 
     #: Typesafe equality comparison with other `Result` objects.
@@ -305,6 +307,8 @@ class IOResult(
     Do not rely on them! Use public functions and types instead.
 
     """
+
+    __slots__ = ()
 
     _inner_value: Result[_ValueType, _ErrorType]
     __match_args__ = ('_inner_value',)
@@ -752,6 +756,8 @@ class IOResult(
 class IOFailure(IOResult[Any, _ErrorType]):
     """``IOFailure`` representation."""
 
+    __slots__ = ()
+
     _inner_value: Result[Any, _ErrorType]
 
     def __init__(self, inner_value: _ErrorType) -> None:
@@ -782,6 +788,8 @@ class IOFailure(IOResult[Any, _ErrorType]):
 @final
 class IOSuccess(IOResult[_ValueType, Any]):
     """``IOSuccess`` representation."""
+
+    __slots__ = ()
 
     _inner_value: Result[_ValueType, Any]
 

--- a/returns/iterables.py
+++ b/returns/iterables.py
@@ -44,6 +44,8 @@ class AbstractFold(object):
     change an implementation of any unkinded protected method.
     """
 
+    __slots__ = ()
+
     @final
     @kinded
     @classmethod
@@ -313,6 +315,8 @@ class Fold(AbstractFold):
 
     Use it by default.
     """
+
+    __slots__ = ()
 
     @classmethod
     def _loop(

--- a/returns/maybe.py
+++ b/returns/maybe.py
@@ -46,6 +46,8 @@ class Maybe(
 
     """
 
+    __slots__ = ()
+
     _inner_value: Optional[_ValueType]
     __match_args__ = ('_inner_value',)
 
@@ -286,6 +288,8 @@ class Maybe(
 class _Nothing(Maybe[Any]):
     """Represents an empty state."""
 
+    __slots__ = ()
+
     _inner_value: None
     _instance: Optional['_Nothing'] = None
 
@@ -362,6 +366,8 @@ class Some(Maybe[_ValueType]):
 
     Quite similar to ``Success`` type.
     """
+
+    __slots__ = ()
 
     _inner_value: _ValueType
 

--- a/returns/primitives/hkt.py
+++ b/returns/primitives/hkt.py
@@ -126,6 +126,8 @@ class SupportsKindN(
     Needless to say, that ``__getattr__`` during runtime - never exists at all.
     """
 
+    __slots__ = ()
+
     __getattr__: None  # type: ignore
 
 
@@ -193,6 +195,8 @@ class Kinded(Protocol[_FunctionDefType]):  # type: ignore
     We use a custom ``mypy`` plugin to make sure types are correct.
     Otherwise, it is currently impossible to properly type this.
     """
+
+    __slots__ = ()
 
     #: Used to translate `KindN` into real types.
     __call__: _FunctionDefType

--- a/returns/primitives/laws.py
+++ b/returns/primitives/laws.py
@@ -45,6 +45,8 @@ class Law1(
 ):
     """Law definition for functions with a single argument."""
 
+    __slots__ = ()
+
     definition: Callable[['Law1', _TypeArgType1], _ReturnType]
 
     def __init__(
@@ -62,6 +64,8 @@ class Law2(
 ):
     """Law definition for functions with two arguments."""
 
+    __slots__ = ()
+
     definition: Callable[['Law2', _TypeArgType1, _TypeArgType2], _ReturnType]
 
     def __init__(
@@ -78,6 +82,8 @@ class Law3(
     Generic[_TypeArgType1, _TypeArgType2, _TypeArgType3, _ReturnType],
 ):
     """Law definition for functions with three argument."""
+
+    __slots__ = ()
 
     definition: Callable[
         ['Law3', _TypeArgType1, _TypeArgType2, _TypeArgType3],
@@ -101,6 +107,8 @@ class Lawful(Generic[_Caps]):
 
     Allows to smartly collect all defined laws from all parent classes.
     """
+
+    __slots__ = ()
 
     #: Some classes and interfaces might have laws, some might not have any.
     _laws: ClassVar[Sequence[Law]]

--- a/returns/primitives/types.py
+++ b/returns/primitives/types.py
@@ -27,6 +27,8 @@ class Immutable(object):
 
     """  # noqa: RST307
 
+    __slots__ = ()
+
     def __copy__(self) -> 'Immutable':
         """Returns itself."""
         return self

--- a/returns/result.py
+++ b/returns/result.py
@@ -319,6 +319,8 @@ class Failure(Result[Any, _ErrorType]):  # noqa: WPS338
     It should contain an error code or message.
     """
 
+    __slots__ = ()
+
     _inner_value: _ErrorType
 
     def __init__(self, inner_value: _ErrorType) -> None:
@@ -380,6 +382,8 @@ class Success(Result[_ValueType, Any]):
 
     Contains the computation value.
     """
+
+    __slots__ = ()
 
     _inner_value: _ValueType
 

--- a/tests/test_contrib/test_pytest/test_plugin_error_handler.py
+++ b/tests/test_contrib/test_pytest/test_plugin_error_handler.py
@@ -6,6 +6,7 @@ from returns.context import (
     RequiresContextResult,
 )
 from returns.contrib.pytest import ReturnsAsserts
+from returns.contrib.pytest.plugin import _ERRORS_HANDLED
 from returns.functions import identity
 from returns.future import FutureResult
 from returns.io import IOFailure, IOSuccess
@@ -41,6 +42,7 @@ def _under_test(
 ])
 def test_error_handled(returns: ReturnsAsserts, container, kwargs):
     """Demo on how to use ``pytest`` helpers to work with error handling."""
+    assert not _ERRORS_HANDLED
     error_handled = _under_test(container, **kwargs)
 
     assert returns.is_error_handled(error_handled)
@@ -62,6 +64,7 @@ def test_error_handled(returns: ReturnsAsserts, container, kwargs):
 ])
 def test_error_not_handled(returns: ReturnsAsserts, container):
     """Demo on how to use ``pytest`` helpers to work with error handling."""
+    assert not _ERRORS_HANDLED
     error_handled = _under_test(container)
 
     assert not returns.is_error_handled(container)

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,0 +1,45 @@
+import importlib
+import inspect
+import pkgutil
+from typing import Any, Iterator
+
+import returns
+
+
+def _classes_in_module(module: Any) -> Iterator[type]:
+    yield from (
+        klass
+        for _, klass in inspect.getmembers(module, inspect.isclass)
+        if klass.__module__.startswith(module.__name__)  # noqa: WPS609
+    )
+    try:
+        module_path = module.__path__[0]  # noqa: WPS609
+    except AttributeError:
+        return  # it's not a package with submodules
+
+    packages = pkgutil.walk_packages([module_path])
+    for finder, name, _ in packages:
+        if not getattr(finder, 'path', '').startswith(module_path):
+            continue
+
+        yield from _classes_in_module(
+            importlib.import_module(
+                '{0.__name__}.{1}'.format(module, name),
+            ),
+        )
+
+
+def _has_slots(klass: type) -> bool:
+    return '__slots__' in klass.__dict__ or klass is object  # noqa: WPS609
+
+
+def test_slots_defined():
+    """Ensures __slots__ isn't forgotten anywhere."""
+    classes_without_slots = {
+        klass
+        for klass in _classes_in_module(returns)
+        if not _has_slots(klass) and
+        all(map(_has_slots, klass.__bases__)) and  # noqa: WPS609
+        not klass.__module__.startswith('returns.contrib')  # noqa: WPS609
+    }
+    assert not classes_without_slots


### PR DESCRIPTION
# I have made things!

- slots added to many _many_ classes
- in pytest plugin, the mechanism for tracking 'errors handled' needed a rework
- test added to prevent forgetting slots in the future

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #1144

## Open questions

In adding `__slots__`, internal changes were needed to the `pytest` plugin.  It works now (as discussed in #1144), but I still have a nagging feeling (monkey-patching and mutable global state will do that... 😉 )

I would like to suggest a follow-up change to the pytest plugin: that it undoes its patches after each test (like `unittest.mock.patch` does). The advantages are:
- classes are only patched when using the special `ReturnsAsserts`. This means it 100% doesn't affect any other tests (i.e. we get more predictable behavior). Currently all tests running _after_ a `returns`-enabled test are patched, those before are not. A very nasty thing to debug if it ever messes with anybody's tests 👀 
- the 'errors handled' mapping doesn't need to be a mutable global variable (👿) , it can be stored in the `ReturnsAsserts` instance.
- the 'errors handled' mapping doesn't need to be cleared after each test 🚀

🤔 Of course, we'll have to see what the performance impact is. Perhaps we might need to split the performance-heavy patching into a separate fixture, so it's only activated when needed