### PR TITLE
cleanup patches after test in pytest plugin (#1148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ See [0Ver](https://0ver.org/).
 ### Bugfixes
 
 - Fixes `__slots__` not being set properly in containers and their base classes
+- Fixes patching of containers in pytest plugin not undone after each test
 
 ## 0.17.0
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,3 +20,7 @@ hypothesis==6.30.0
 # TODO: Remove this lock when we found and fix the route case.
 # See: https://github.com/typlog/sphinx-typlog-theme/issues/22
 jinja2==3.0.3
+
+# TODO: Remove this lock when this dependency issue is resolved.
+# See: https://github.com/miyakogi/m2r/issues/66
+mistune<2.0.0

--- a/returns/contrib/pytest/plugin.py
+++ b/returns/contrib/pytest/plugin.py
@@ -2,17 +2,8 @@ import inspect
 import sys
 from contextlib import ExitStack, contextmanager
 from functools import partial, wraps
-from types import FrameType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Generator,
-    Iterator,
-    TypeVar,
-    Union,
-)
+from types import FrameType, MappingProxyType
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, TypeVar, Union
 from unittest import mock
 
 import pytest
@@ -139,14 +130,14 @@ def pytest_configure(config) -> None:
 
 
 @pytest.fixture()
-def returns() -> Generator[ReturnsAsserts, None, None]:
+def returns() -> Iterator[ReturnsAsserts]:
     """Returns class with helpers assertions to check containers."""
     with _spy_error_handling() as errors_handled:
         yield ReturnsAsserts(errors_handled)
 
 
 @contextmanager
-def _spy_error_handling() -> Generator[_ErrorsHandled, None, None]:
+def _spy_error_handling() -> Iterator[_ErrorsHandled]:
     """Track error handling of containers."""
     errs: _ErrorsHandled = {}
     with ExitStack() as cleanup:
@@ -217,8 +208,8 @@ def _patched_error_copier(
     return wraps(original)(wrapper)  # type: ignore
 
 
-_ERROR_HANDLING_PATCHERS: Final = {  # noqa: WPS407
+_ERROR_HANDLING_PATCHERS: Final = MappingProxyType({
     'lash': _patched_error_handler,
     'map': _patched_error_copier,
     'alt': _patched_error_copier,
-}
+})

--- a/tests/test_contrib/test_pytest/test_plugin_error_handler.py
+++ b/tests/test_contrib/test_pytest/test_plugin_error_handler.py
@@ -6,7 +6,6 @@ from returns.context import (
     RequiresContextResult,
 )
 from returns.contrib.pytest import ReturnsAsserts
-from returns.contrib.pytest.plugin import _ERRORS_HANDLED
 from returns.functions import identity
 from returns.future import FutureResult
 from returns.io import IOFailure, IOSuccess
@@ -42,12 +41,14 @@ def _under_test(
 ])
 def test_error_handled(returns: ReturnsAsserts, container, kwargs):
     """Demo on how to use ``pytest`` helpers to work with error handling."""
-    assert not _ERRORS_HANDLED
+    assert not returns._errors_handled  # noqa: WPS437
     error_handled = _under_test(container, **kwargs)
 
     assert returns.is_error_handled(error_handled)
     assert returns.is_error_handled(error_handled.map(identity))
     assert returns.is_error_handled(error_handled.alt(identity))
+
+    assert returns._errors_handled  # noqa: WPS437
 
 
 @pytest.mark.parametrize('container', [
@@ -64,13 +65,15 @@ def test_error_handled(returns: ReturnsAsserts, container, kwargs):
 ])
 def test_error_not_handled(returns: ReturnsAsserts, container):
     """Demo on how to use ``pytest`` helpers to work with error handling."""
-    assert not _ERRORS_HANDLED
+    assert not returns._errors_handled  # noqa: WPS437
     error_handled = _under_test(container)
 
     assert not returns.is_error_handled(container)
     assert not returns.is_error_handled(error_handled)
     assert not returns.is_error_handled(error_handled.map(identity))
     assert not returns.is_error_handled(error_handled.alt(identity))
+
+    assert not returns._errors_handled  # noqa: WPS437
 
 
 @pytest.mark.anyio()


### PR DESCRIPTION
# I have made things!

As discussed in #1148 and #1147 

excuse the large diff; I took the liberty of rearranging the functions in the module to:
- group them together by functionality
- remove the need for a class which only had staticmethods

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1148 