### PR TITLE
Make `@safe((TypeError, ValueError))` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ See [0Ver](https://0ver.org/).
 - Enables Pattern Matching support for `IOResult` container
 - Improves `hypothesis` plugin, now we detect
   when type cannot be constructed and give a clear error message
+- Adds the option to pass what exceptions `@safe` will handle
 
 
 ## 0.16.0

--- a/docs/pages/result.rst
+++ b/docs/pages/result.rst
@@ -99,6 +99,13 @@ use :func:`future_safe <returns.future.future_safe>` instead.
   >>> str(divide(0))
   '<Failure: division by zero>'
 
+If you want to `safe` handle only a set of exceptions:
+
+.. code:: python
+
+  >>> @safe((ZeroDivisionError,))  # It'll handle only `ZeroDivisionError`
+  ... def divide(number: int) -> float:
+  ...     return number / number
 
 FAQ
 ---

--- a/docs/pages/result.rst
+++ b/docs/pages/result.rst
@@ -103,9 +103,18 @@ If you want to `safe` handle only a set of exceptions:
 
 .. code:: python
 
-  >>> @safe((ZeroDivisionError,))  # It'll handle only `ZeroDivisionError`
+  >>> @safe(exceptions=(ZeroDivisionError,))  # Other exceptions will be raised
   ... def divide(number: int) -> float:
+  ...     if number > 10:
+  ...         raise ValueError('Too big')
   ...     return number / number
+
+  >>> assert divide(5) == Success(1.0)
+  >>> assert divide(0).failure()
+  >>> divide(15)
+  Traceback (most recent call last):
+    ...
+  ValueError: Too big
 
 FAQ
 ---

--- a/returns/result.py
+++ b/returns/result.py
@@ -526,6 +526,6 @@ def safe(  # type: ignore # noqa: WPS234, C901
     if callable(function):
         return factory(function, (Exception,))
     if isinstance(function, tuple):
-        exceptions = function
+        exceptions = function  # type: ignore
         function = None
     return lambda function: factory(function, exceptions)  # type: ignore

--- a/returns/result.py
+++ b/returns/result.py
@@ -506,7 +506,7 @@ def safe(  # type: ignore # noqa: WPS234, C901
       >>> assert isinstance(might_raise(0), Result.failure_type)
 
     In this case, only exceptions that are explicitly
-    listed are going to be catched.
+    listed are going to be caught.
 
     Similar to :func:`returns.io.impure_safe`
     and :func:`returns.future.future_safe` decorators.

--- a/returns/result.py
+++ b/returns/result.py
@@ -461,7 +461,7 @@ def safe(
     """Decorator to convert exception-throwing just for a set of Exceptions."""
 
 
-def safe(  # type: ignore # noqa: WPS234
+def safe(  # type: ignore # noqa: WPS234, C901
     function: Optional[Callable[_FuncParams, _ValueType]] = None,
     exceptions: Optional[Tuple[Type[Exception], ...]] = None,
 ) -> Union[

--- a/tests/test_result/test_result_functions/test_safe.py
+++ b/tests/test_result/test_result_functions/test_safe.py
@@ -10,8 +10,14 @@ def _function(number: int) -> float:
     return number / number
 
 
-@safe(arg=(ZeroDivisionError,))
+@safe(exceptions=(ZeroDivisionError,))
 def _function_two(number: Union[int, str]) -> float:
+    assert isinstance(number, int)
+    return number / number
+
+
+@safe((ZeroDivisionError,))  # no name
+def _function_three(number: Union[int, str]) -> float:
     assert isinstance(number, int)
     return number / number
 
@@ -31,6 +37,9 @@ def test_safe_failure_with_expected_error():
     """Ensures that safe decorator works correctly for Failure case."""
     failed = _function_two(0)
     assert isinstance(failed.failure(), ZeroDivisionError)
+
+    failed2 = _function_three(0)
+    assert isinstance(failed2.failure(), ZeroDivisionError)
 
 
 def test_safe_failure_with_non_expected_error():

--- a/tests/test_result/test_result_functions/test_safe.py
+++ b/tests/test_result/test_result_functions/test_safe.py
@@ -1,9 +1,18 @@
+from typing import Union
+
+import pytest
 
 from returns.result import Success, safe
 
 
 @safe
 def _function(number: int) -> float:
+    return number / number
+
+
+@safe(arg=(ZeroDivisionError,))
+def _function_two(number: Union[int, str]) -> float:
+    assert isinstance(number, int)
     return number / number
 
 
@@ -16,3 +25,15 @@ def test_safe_failure():
     """Ensures that safe decorator works correctly for Failure case."""
     failed = _function(0)
     assert isinstance(failed.failure(), ZeroDivisionError)
+
+
+def test_safe_failure_with_expected_error():
+    """Ensures that safe decorator works correctly for Failure case."""
+    failed = _function_two(0)
+    assert isinstance(failed.failure(), ZeroDivisionError)
+
+
+def test_safe_failure_with_non_expected_error():
+    """Ensures that safe decorator works correctly for Failure case."""
+    with pytest.raises(AssertionError):
+        _function_two('0')

--- a/typesafety/test_result/test_safe.yml
+++ b/typesafety/test_result/test_safe.yml
@@ -10,6 +10,18 @@
     reveal_type(test)  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
+- case: safe_decorator_passing_exceptions_no_params
+  disable_cache: false
+  main: |
+    from returns.result import safe
+
+    @safe((ValueError,))
+    def test() -> int:
+        return 1
+
+    reveal_type(test)  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
+
+
 - case: safe_composition_no_params
   disable_cache: false
   main: |
@@ -21,6 +33,17 @@
     reveal_type(safe(test))  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
+- case: safe_composition_passing_exceptions_no_params
+  disable_cache: false
+  main: |
+    from returns.result import safe
+
+    def test() -> int:
+        return 1
+
+    reveal_type(safe((EOFError,))(test))  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
+
+
 - case: safe_decorator_with_args
   disable_cache: false
   main: |
@@ -28,6 +51,19 @@
     from returns.result import safe
 
     @safe
+    def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
+        return 1
+
+    reveal_type(test)  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.result.Result[builtins.int, builtins.Exception]"
+
+
+- case: safe_decorator_passing_exceptions_with_args
+  disable_cache: false
+  main: |
+    from typing import Optional
+    from returns.result import safe
+
+    @safe((ValueError, EOFError))
     def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
         return 1
 
@@ -46,6 +82,18 @@
     reveal_type(safe(test))  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
+- case: safe_composition_passing_exceptions_with_args
+  disable_cache: false
+  main: |
+    from typing import Optional
+    from returns.result import safe
+
+    def test(first: int, second: Optional[str] = None, *, kw: bool = True) -> int:
+        return 1
+
+    reveal_type(safe((ValueError,))(test))  # N: Revealed type is "def (first: builtins.int, second: Union[builtins.str, None] =, *, kw: builtins.bool =) -> returns.result.Result[builtins.int, builtins.Exception]"
+
+
 - case: safe_regression333
   disable_cache: false
   main: |
@@ -53,6 +101,19 @@
     from typing import Any
 
     @safe
+    def send(text: str) -> Any:
+        return "test"
+
+    reveal_type(send)  # N: Revealed type is "def (text: builtins.str) -> returns.result.Result[Any, builtins.Exception]"
+
+
+- case: safe_passing_exceptions_regression333
+  disable_cache: false
+  main: |
+    from returns.result import safe
+    from typing import Any
+
+    @safe((Exception,))
     def send(text: str) -> Any:
         return "test"
 
@@ -72,12 +133,37 @@
     reveal_type(safe(tap(Response.raise_for_status)))  # N: Revealed type is "def (main.Response*) -> returns.result.Result[main.Response, builtins.Exception]"
 
 
+- case: safe_passing_exceptions_regression641
+  disable_cache: false
+  main: |
+    from returns.result import safe
+    from returns.functions import tap
+
+    class Response(object):
+        def raise_for_status(self) -> None:
+            ...
+
+    reveal_type(safe((EOFError,))(tap(Response.raise_for_status)))  # N: Revealed type is "def (main.Response*) -> returns.result.Result[main.Response, builtins.Exception]"
+
+
 - case: safe_decorator_with_args_kwargs
   disable_cache: false
   main: |
     from returns.result import safe
 
     @safe
+    def test(*args, **kwargs) -> int:
+        return 1
+
+    reveal_type(test)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> returns.result.Result[builtins.int, builtins.Exception]"
+
+
+- case: safe_decorator_passing_exceptions_with_args_kwargs
+  disable_cache: false
+  main: |
+    from returns.result import safe
+
+    @safe((EOFError,))
     def test(*args, **kwargs) -> int:
         return 1
 
@@ -96,6 +182,18 @@
     reveal_type(test)  # N: Revealed type is "def (*args: builtins.int, **kwargs: builtins.str) -> returns.result.Result[builtins.int, builtins.Exception]"
 
 
+- case: safe_decorator_passing_exceptions_with_args_kwargs
+  disable_cache: false
+  main: |
+    from returns.result import safe
+
+    @safe((Exception,))
+    def test(*args: int, **kwargs: str) -> int:
+        return 1
+
+    reveal_type(test)  # N: Revealed type is "def (*args: builtins.int, **kwargs: builtins.str) -> returns.result.Result[builtins.int, builtins.Exception]"
+
+
 - case: safe_decorator_composition
   disable_cache: false
   main: |
@@ -104,6 +202,20 @@
 
     @impure
     @safe
+    def test(*args: int, **kwargs: str) -> int:
+        return 1
+
+    reveal_type(test)  # N: Revealed type is "def (*args: builtins.int, **kwargs: builtins.str) -> returns.io.IO[returns.result.Result*[builtins.int*, builtins.Exception]]"
+
+
+- case: safe_decorator_passing_exceptions_composition
+  disable_cache: false
+  main: |
+    from returns.io import impure
+    from returns.result import safe
+
+    @impure
+    @safe((ValueError,))
     def test(*args: int, **kwargs: str) -> int:
         return 1
 

--- a/typesafety/test_result/test_safe.yml
+++ b/typesafety/test_result/test_safe.yml
@@ -21,6 +21,12 @@
 
     reveal_type(test)  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
 
+    @safe(exceptions=(ValueError,))
+    def test2() -> int:
+        return 1
+
+    reveal_type(test2)  # N: Revealed type is "def () -> returns.result.Result[builtins.int, builtins.Exception]"
+
 
 - case: safe_composition_no_params
   disable_cache: false


### PR DESCRIPTION
# Make `@safe((TypeError, ValueError))` variant

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #605 