### PR TITLE
run slotscheck explicitly on files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         poetry run poetry check
         poetry run pip check
         poetry run safety check --full-report
-        poetry run slotscheck returns --verbose
+        poetry run python -m slotscheck returns --verbose
         # We do this to speed up the build:
         poetry run pytest typesafety -p no:cov -o addopts="" --mypy-ini-file=setup.cfg
 


### PR DESCRIPTION
# I have made things!

`slotscheck` will become more strict about import paths in the future. I'm changing the invocation here to ensure `slotscheck` runs on the _files_, not the installed package. Running with `python -m` ensures the current working directory is in `sys.path` so the correct files are imported.

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] ~I have created at least one test case for the changes I have made~ n/a
- [x] ~I have updated the documentation for the changes I have made~ n/a
- [x] ~I have added my changes to the `CHANGELOG.md`~ n/a

## Related issues

#1233 