### PR TITLE
Use format string in pattern matching example

### DIFF
--- a/tests/test_examples/test_result/test_result_pattern_matching.py
+++ b/tests/test_examples/test_result/test_result_pattern_matching.py
@@ -13,7 +13,7 @@ match div(1, 0):
 
     # Matches any `Success` instance and binds its value to the `value` variable
     case Success(value):
-        print('Result is "{0}"'.format(value))
+        print(f'Result is "{value}"')
 
     # Matches if the result stored inside `Failure` is `ZeroDivisionError`
     case Failure(ZeroDivisionError):


### PR DESCRIPTION
## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Summary

`test_result_pattern_matching.py` shows up in the generated docs. Simplify string formatting by using format strings.

- https://returns.readthedocs.io/en/latest/pages/result.html#pattern-matching