### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/pages/interfaces.rst
+++ b/docs/pages/interfaces.rst
@@ -575,7 +575,7 @@ do not have type aliases for one type argument in a form of ``ResultLike1``.
 Why does ``Mappable1`` exists and ``ResultLike1`` does not?
 
 Because ``Mappable1`` does make sense.
-But, ``ResultLike1`` requiers at least two (value and error) types to exist.
+But, ``ResultLike1`` requires at least two (value and error) types to exist.
 The same applies for ``ReaderLike1`` and ``ReaderResultLike1``
 and ``ReaderResultLike2``.
 

--- a/returns/primitives/reawaitable.py
+++ b/returns/primitives/reawaitable.py
@@ -16,7 +16,7 @@ class ReAwaitable(object):
     Allows to write coroutines that can be awaited multiple times.
 
     It works by actually caching the ``await`` result and reusing it.
-    So, in reallity we still ``await`` once,
+    So, in reality we still ``await`` once,
     but pretending to do it multiple times.
 
     Why is that required? Because otherwise,


### PR DESCRIPTION
There are small typos in:
- docs/pages/interfaces.rst
- returns/primitives/reawaitable.py

Fixes:
- Should read `requires` rather than `requiers`.
- Should read `reality` rather than `reallity`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md