### PR TITLE
Fixes custom pickle protocol to handle `None` values as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See [0Ver](https://0ver.org/).
 ### Bugfixes
 
 - Fixes a problem with `do-notation` and type aliases
+- Fixes custom pickle protocol to handle `None` values gracefully
 
 
 ## 0.19.0 aka The Do Notation

--- a/tests/test_io/test_io_container/test_io_pickle.py
+++ b/tests/test_io/test_io_container/test_io_pickle.py
@@ -3,11 +3,11 @@ from returns.io import IO
 
 def test_io_pickle():
     """Tests how pickle protocol works for containers."""
-    assert IO(1).__getstate__() == 1  # noqa: WPS609
+    assert IO(1).__getstate__() == {'container_value': 1}  # noqa: WPS609
 
 
 def test_io_pickle_restore():
     """Ensures that object can be restored."""
     container = IO(2)
-    container.__setstate__(1)  # noqa: WPS609
+    container.__setstate__({'container_value': 1})  # type: ignore  # noqa: WPS609, E501
     assert container == IO(1)

--- a/tests/test_primitives/test_container/test_base_container/test_pickle.py
+++ b/tests/test_primitives/test_container/test_base_container/test_pickle.py
@@ -26,7 +26,7 @@ class _CustomClass(object):
         st.booleans(),
         st.lists(st.text()),
         st.dictionaries(st.text(), st.integers()),
-        st.builds(_CustomClass, st.text()),
+        st.from_type(_CustomClass),
     ),
 )
 @example(None)

--- a/tests/test_primitives/test_container/test_base_container/test_pickle.py
+++ b/tests/test_primitives/test_container/test_base_container/test_pickle.py
@@ -26,7 +26,7 @@ class _CustomClass(object):
         st.booleans(),
         st.lists(st.text()),
         st.dictionaries(st.text(), st.integers()),
-        st.from_type(_CustomClass),
+        st.builds(_CustomClass, st.text()),
     ),
 )
 @example(None)

--- a/tests/test_primitives/test_container/test_base_container/test_pickle.py
+++ b/tests/test_primitives/test_container/test_base_container/test_pickle.py
@@ -1,0 +1,36 @@
+import pickle  # noqa: S403
+from typing import Any
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+from returns.primitives.container import BaseContainer
+
+
+class _CustomClass(object):
+    def __init__(self, inner_value: Any) -> None:
+        self.inner_value = inner_value
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            type(other) == type(self) and  # noqa: WPS516
+            self.inner_value == other.inner_value
+        )
+
+
+@given(
+    st.one_of(
+        st.integers(),
+        st.floats(allow_nan=False),
+        st.text(),
+        st.booleans(),
+        st.lists(st.text()),
+        st.dictionaries(st.text(), st.integers()),
+        st.builds(_CustomClass, st.text()),
+    ),
+)
+@example(None)
+def test_pickle(container_value: Any):
+    """Ensures custom pickle protocol works as expected."""
+    container = BaseContainer(container_value)
+    assert pickle.loads(pickle.dumps(container)) == container  # noqa: S301


### PR DESCRIPTION
# Fixes custom pickle protocol to handle `None` values as well

I've created an intermediate representation to Pickle/Unpickle objects to handle `None` values too! What's happening now is:
* Pickle calls `__getstate__`, which returns a value (that can be `None`)
* Pickle calls `__setstate__` __ONLY__ the value is not `None` in the `__getstate__` phase

```text
Note If __getstate__() returns a false value, the __setstate__() method will not be called upon unpickling.
```
[source](https://docs.python.org/3/library/pickle.html#object.__setstate__)

With the changes introduced by this PR all values are wrapped in a dict, this way we preserve the value even if it's `None`!

## Checklist

<!-- Please check everything that applies: -->

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [X] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #1405 