### PR TITLE
Issue 1396 - Broken link to drylabs.io on the bottom of README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See [0Ver](https://0ver.org/).
 
 - Fixes a problem with `do-notation` and type aliases
 - Fixes custom pickle protocol to handle `None` values gracefully
+- Removes broken drylabs.io link in README
 
 
 ## 0.19.0 aka The Do Notation

--- a/README.md
+++ b/README.md
@@ -639,7 +639,3 @@ Or read these articles:
 - [Make Tests a Part of Your App](https://sobolevn.me/2021/02/make-tests-a-part-of-your-app)
 
 Do you have an article to submit? Feel free to open a pull request!
-
-<p align="center">&mdash; ⭐️ &mdash;</p>
-<p align="center"><i>Drylabs maintains dry-python and helps those who want to use it inside their organizations.</i></p>
-<p align="center"><i>Read more at <a href="https://drylabs.io">drylabs.io</a></i></p>


### PR DESCRIPTION
Replace drylabs.io with dry-labs.github.io (working as of 2022-09-09)

# I have made things!

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #1396 

