### PR TITLE
fix tiny typo in docs

### DIFF
--- a/docs/pages/create-your-own-container.rst
+++ b/docs/pages/create-your-own-container.rst
@@ -112,7 +112,7 @@ Let's look at the result:
 
 .. note::
   A special note on :class:`returns.primitives.container.BaseContainer`.
-  It is a very useful class with lots of pre-defined feaatures, like:
+  It is a very useful class with lots of pre-defined features, like:
   immutability, better cloning, serialization, and comparison.
 
   You can skip it if you wish, but it is highlighly recommended.


### PR DESCRIPTION
# I have made things!

found a tiny typo while reading the docs

## Checklist


- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] ~I have created at least one test case for the changes I have made~
- [x] ~I have updated the documentation for the changes I have made~
- [x] ~I have added my changes to the `CHANGELOG.md`~