### PR TITLE
Add mypy-plugin extra dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install dependencies
       run: |
         poetry config virtualenvs.in-project true
-        poetry install
+        poetry install --extras=compatible-mypy
 
         poetry run pip install -U pip
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ You are also required to [configure](https://returns.readthedocs.io/en/latest/pa
 `mypy` correctly and install our plugin
 to fix [this existing issue](https://github.com/python/mypy/issues/3157):
 
+```bash
+pip install returns[compatible-mypy]
+```
+and
+
 ```ini
 # In setup.cfg or mypy.ini:
 [mypy]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2581,4 +2581,4 @@ compatible-mypy = ["mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "60e0b58b295abf5d7fc913a729b929391cab28055c4b4f4f8eb58abccf8af6f5"
+content-hash = "18cd7cc3d91537f3b193acaf27bd3ef3cc631ad259f53b0e399cdea074659721"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2575,7 +2575,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+compatible-mypy = ["mypy"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "a48e1ac3c47dfccb3d1ff8503c9ef171b17ca3177ce09d2a7abc2709dc24f2b3"
+content-hash = "60e0b58b295abf5d7fc913a729b929391cab28055c4b4f4f8eb58abccf8af6f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ trio = "^0.22"
 attrs = "^23.1"
 httpx = "^0.24"
 
-mypy = "^1.4.0"
 wemake-python-styleguide = "^0.17"
 flake8-pytest-style = "^1.6"
 flake8-pyi = "^23.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ _ = "returns.contrib.hypothesis._entrypoint"
 python = "^3.7"
 
 typing-extensions = ">=4.0,<5.0"
+mypy = { version = "^1.4.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 anyio = "^3.7"
@@ -55,7 +56,7 @@ trio = "^0.22"
 attrs = "^23.1"
 httpx = "^0.24"
 
-mypy = "^1.4"
+mypy = "^1.4.0"
 wemake-python-styleguide = "^0.17"
 flake8-pytest-style = "^1.6"
 flake8-pyi = "^23.4"
@@ -80,6 +81,9 @@ sphinx-hoverxref = "^1.3"
 doc8 = "^1.0"
 m2r2 = "^0.3"
 tomlkit = "^0.11"
+
+[tool.poetry.extras]
+compatible-mypy = ["mypy"]
 
 
 [build-system]


### PR DESCRIPTION
use `pip install classes[compatible-mypy]` for installing additional dependencies required by the mypy-plugin.

# I have made things!

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->

🙏 Please, if you or your company finds `dry-python` valuable, help us sustain the project by sponsoring it transparently on https://github.com/sponsors/dry-python. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
