### PR TITLE
Add annotation to Unwrappable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ See [0Ver](https://0ver.org/).
 - Improve inference of `ResultLike` objects when exception catching
   decorator is applied with explicit exception types
 - Add picky exceptions to `impure_safe` decorator like `safe` has. Issue #1543
-- Unwrappable annotated for suppressing reportUnknownVariableType when importing for Pyright checks
 
 ### Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [0Ver](https://0ver.org/).
 - Improve inference of `ResultLike` objects when exception catching
   decorator is applied with explicit exception types
 - Add picky exceptions to `impure_safe` decorator like `safe` has. Issue #1543
+- Unwrappable annotated for suppressing reportUnknownVariableType when importing for Pyright checks
 
 ### Misc
 

--- a/returns/pipeline.py
+++ b/returns/pipeline.py
@@ -1,4 +1,4 @@
-from typing import ClassVar
+from typing import Any
 
 from returns._internal.pipeline.flow import flow as flow
 from returns._internal.pipeline.managed import managed as managed
@@ -8,7 +8,7 @@ from returns.primitives.exceptions import UnwrapFailedError
 
 
 # TODO: add overloads for specific types, so it can narrow them with `TypeIs`
-def is_successful(container: Unwrappable) -> bool:
+def is_successful(container: Unwrappable[Any, Any]) -> bool:
     """
     Determines if a container was successful or not.
 


### PR DESCRIPTION
# I have added silly annotation to Unwrappable type for getting rid of Pyright error `reportUnknownVariableType`

Note: it requires _new_ version of Pyright

## Checklist

<!-- Please check everything that applies: -->

- [x ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
