### PR TITLE
docs: fix typos (#1924)

### DIFF
--- a/docs/pages/container.rst
+++ b/docs/pages/container.rst
@@ -16,7 +16,7 @@ List of supported containers:
 - :class:`RequiresContext <returns.context.requires_context.RequiresContext>`
   to pass context to your functions (DI and similar)
 
-There are also some combintations like
+There are also some combinations like
 :class:`IOResult <returns.io.IOResult>`,
 :class:`FutureResult <returns.future.FutureResult>`,
 :class:`RequiresContextResult <.RequiresContextResult>`,

--- a/docs/pages/contrib/hypothesis_plugins.rst
+++ b/docs/pages/contrib/hypothesis_plugins.rst
@@ -72,7 +72,7 @@ check_all_laws
 --------------
 
 We also provide a very powerful mechanism of checking defined container laws.
-It works in a combitation with "Laws as Values" feature we provide in the core.
+It works in a combination with "Laws as Values" feature we provide in the core.
 
 .. code:: python
 

--- a/docs/pages/do-notation.rst
+++ b/docs/pages/do-notation.rst
@@ -88,7 +88,7 @@ Async containers
 We also support async containers like ``Future`` and ``FutureResult``.
 It works in a similar way as regular sync containers.
 But, they require ``async for`` expressions instead of regular ``for`` ones.
-And because of that - they cannot be used outsided of ``async def`` context.
+And because of that - they cannot be used outside of ``async def`` context.
 
 Usage example:
 

--- a/docs/pages/interfaces.rst
+++ b/docs/pages/interfaces.rst
@@ -76,7 +76,7 @@ The last criteria we have to decided on naming is
 That's why we have ``ResultLikeN`` and ``ResultBasedN`` interfaces.
 Because ``ResultBasedN`` has two extra methods compared to ``ResultLikeN``.
 We use ``Like`` suffix for interfaces that describes some similar types.
-We use ``Based`` suffix for interfaces that descire almost concrete types.
+We use ``Based`` suffix for interfaces that describe almost concrete types.
 
 Laws
 ~~~~

--- a/docs/pages/result.rst
+++ b/docs/pages/result.rst
@@ -174,7 +174,7 @@ You might want to sometimes use ``unify`` :ref:`pointfree` functions
 instead of ``.bind`` to compose error types together.
 While ``.bind`` enforces error type to stay the same,
 ``unify`` is designed
-to return a ``Union`` of a revious error type and a new one.
+to return a ``Union`` of a previous error type and a new one.
 
 It gives an extra flexibility, but also provokes more thinking
 and can be problematic in some cases.


### PR DESCRIPTION
This PR fixes some minor typos in the documentation.

Closes #1924