### PR TITLE
fix (laws/pure): compatibility with hypothesis > 6.113.0

### DIFF
--- a/returns/contrib/hypothesis/laws.py
+++ b/returns/contrib/hypothesis/laws.py
@@ -179,10 +179,10 @@ def pure_functions() -> Iterator[None]:
 
 def _get_callable_type() -> Any:
     # Helper to accommodate changes in `hypothesis@6.79.0`
-    if Callable in types._global_type_lookup:  # type: ignore
-        return Callable
-    elif Callable.__origin__ in types._global_type_lookup:  # type: ignore
+    if Callable.__origin__ in types._global_type_lookup:  # type: ignore
         return Callable.__origin__  # type: ignore
+    elif Callable in types._global_type_lookup:  # type: ignore
+        return Callable
     raise RuntimeError('Failed to find Callable type strategy')
 
 


### PR DESCRIPTION
Hypothesis is now setting two entries for the Callables strategies, and then it prefers the one using the type origin. While returns lookup for the first set and replaces the strategy, starting with the one without the type origin.

This only changes the callable strategy search order to match hypothesis, alternatively we could set both.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`
