### PR TITLE
Fix: Add pickle support for UnwrapFailedError (#2048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,13 @@ See [0Ver](https://0ver.org/).
 - Add `default_error` parameter to `returns.converters.maybe_to_result`,
   which provides a default error value for `Failure`
 
+
+## 0.24.1
+
 ### Bugfixes
 
 - Add pickling support for `UnwrapFailedError` exception
+
 
 ## 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ See [0Ver](https://0ver.org/).
 - Add `default_error` parameter to `returns.converters.maybe_to_result`,
   which provides a default error value for `Failure`
 
+### Bugfixes
+
+- Add pickling support for `UnwrapFailedError` exception
 
 ## 0.23.0
 

--- a/returns/primitives/exceptions.py
+++ b/returns/primitives/exceptions.py
@@ -23,7 +23,7 @@ class UnwrapFailedError(Exception):
 
     def __reduce__(self):  # noqa: WPS603
         """Custom reduce method for pickle protocol.
-        
+
         This helps properly reconstruct the exception during unpickling.
         """
         return (

--- a/returns/primitives/exceptions.py
+++ b/returns/primitives/exceptions.py
@@ -23,7 +23,7 @@ class UnwrapFailedError(Exception):
 
     def __reduce__(self):  # noqa: WPS603
         """Custom reduce method for pickle protocol.
-
+        
         This helps properly reconstruct the exception during unpickling.
         """
         return (

--- a/returns/primitives/exceptions.py
+++ b/returns/primitives/exceptions.py
@@ -21,7 +21,7 @@ class UnwrapFailedError(Exception):
         super().__init__()
         self.halted_container = container
 
-    def __reduce__(self):
+    def __reduce__(self):  # noqa: WPS603
         """Custom reduce method for pickle protocol.
         
         This helps properly reconstruct the exception during unpickling.

--- a/returns/primitives/exceptions.py
+++ b/returns/primitives/exceptions.py
@@ -21,6 +21,15 @@ class UnwrapFailedError(Exception):
         super().__init__()
         self.halted_container = container
 
+    def __reduce__(self):
+        """Custom reduce method for pickle protocol.
+        
+        This helps properly reconstruct the exception during unpickling.
+        """
+        return (
+            self.__class__,  # callable
+            (self.halted_container,),  # args to callable
+        )
 
 class ImmutableStateError(AttributeError):
     """

--- a/returns/primitives/exceptions.py
+++ b/returns/primitives/exceptions.py
@@ -23,13 +23,14 @@ class UnwrapFailedError(Exception):
 
     def __reduce__(self):  # noqa: WPS603
         """Custom reduce method for pickle protocol.
-        
+
         This helps properly reconstruct the exception during unpickling.
         """
         return (
             self.__class__,  # callable
             (self.halted_container,),  # args to callable
         )
+
 
 class ImmutableStateError(AttributeError):
     """

--- a/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
+++ b/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
@@ -12,10 +12,10 @@ def test_pickle_unwrap_failed_error_from_maybe():
     except UnwrapFailedError as error:
         # Serialize the error
         serialized = pickle.dumps(error)
-        
+
         # Deserialize
         deserialized_error = pickle.loads(serialized)  # noqa: S301
-        
+
         # Check that halted_container is preserved
         assert deserialized_error.halted_container == Nothing
         assert deserialized_error.halted_container != Some(None)
@@ -28,10 +28,10 @@ def test_pickle_unwrap_failed_error_from_result():
     except UnwrapFailedError as error:
         # Serialize the error
         serialized = pickle.dumps(error)
-        
+
         # Deserialize
         deserialized_error = pickle.loads(serialized)  # noqa: S301
-        
+
         # Check that halted_container is preserved
         assert deserialized_error.halted_container == Failure('error')
         assert deserialized_error.halted_container != Success('error')

--- a/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
+++ b/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
@@ -7,31 +7,42 @@ from returns.result import Failure, Success
 
 def test_pickle_unwrap_failed_error_from_maybe():
     """Ensures that UnwrapFailedError with Maybe can be pickled."""
+    error = None
+    serialized = None
+    error = None
     try:
         Nothing.unwrap()  # This will raise UnwrapFailedError
     except UnwrapFailedError as error:
         # Serialize the error
         serialized = pickle.dumps(error)
 
-        # Deserialize
-        deserialized_error = pickle.loads(serialized)  # noqa: S301
+    assert error is not None
+    assert serialized is not None
 
-        # Check that halted_container is preserved
-        assert deserialized_error.halted_container == Nothing
-        assert deserialized_error.halted_container != Some(None)
+    # Deserialize
+    deserialized_error = pickle.loads(serialized)  # noqa: S301
+
+    # Check that halted_container is preserved
+    assert deserialized_error.halted_container == Nothing
+    assert deserialized_error.halted_container != Some(None)
 
 
 def test_pickle_unwrap_failed_error_from_result():
     """Ensures that UnwrapFailedError with Result can be pickled."""
+    error = None
+    serialized = None
+    error = None
     try:
         Failure('error').unwrap()  # This will raise UnwrapFailedError
     except UnwrapFailedError as error:
         # Serialize the error
         serialized = pickle.dumps(error)
 
-        # Deserialize
-        deserialized_error = pickle.loads(serialized)  # noqa: S301
+    assert error is not None
+    assert serialized is not None
 
-        # Check that halted_container is preserved
-        assert deserialized_error.halted_container == Failure('error')
-        assert deserialized_error.halted_container != Success('error')
+    # Deserialize
+    deserialized_error = pickle.loads(serialized)  # noqa: S301
+    # Check that halted_container is preserved
+    assert deserialized_error.halted_container == Failure('error')
+    assert deserialized_error.halted_container != Success('error')

--- a/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
+++ b/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
@@ -7,7 +7,6 @@ from returns.result import Failure, Success
 
 def test_pickle_unwrap_failed_error_from_maybe():
     """Ensures that UnwrapFailedError with Maybe can be pickled."""
-    error = None
     serialized = None
     try:
         Nothing.unwrap()  # This will raise UnwrapFailedError
@@ -25,7 +24,6 @@ def test_pickle_unwrap_failed_error_from_maybe():
 
 def test_pickle_unwrap_failed_error_from_result():
     """Ensures that UnwrapFailedError with Result can be pickled."""
-    error = None
     serialized = None
     try:
         Failure('error').unwrap()  # This will raise UnwrapFailedError

--- a/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
+++ b/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
@@ -1,8 +1,8 @@
 import pickle  # noqa: S403
 
-from returns.maybe import Nothing, Some
+from returns.maybe import Nothing
 from returns.primitives.exceptions import UnwrapFailedError
-from returns.result import Failure, Success
+from returns.result import Failure
 
 
 def test_pickle_unwrap_failed_error_from_maybe():

--- a/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
+++ b/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
@@ -1,0 +1,37 @@
+import pickle  # noqa: S403
+
+from returns.maybe import Nothing, Some
+from returns.primitives.exceptions import UnwrapFailedError
+from returns.result import Failure, Success
+
+
+def test_pickle_unwrap_failed_error_from_maybe():
+    """Ensures that UnwrapFailedError with Maybe can be pickled."""
+    try:
+        Nothing.unwrap()  # This will raise UnwrapFailedError
+    except UnwrapFailedError as error:
+        # Serialize the error
+        serialized = pickle.dumps(error)
+        
+        # Deserialize
+        deserialized_error = pickle.loads(serialized)  # noqa: S301
+        
+        # Check that halted_container is preserved
+        assert deserialized_error.halted_container == Nothing
+        assert deserialized_error.halted_container != Some(None)
+
+
+def test_pickle_unwrap_failed_error_from_result():
+    """Ensures that UnwrapFailedError with Result can be pickled."""
+    try:
+        Failure('error').unwrap()  # This will raise UnwrapFailedError
+    except UnwrapFailedError as error:
+        # Serialize the error
+        serialized = pickle.dumps(error)
+        
+        # Deserialize
+        deserialized_error = pickle.loads(serialized)  # noqa: S301
+        
+        # Check that halted_container is preserved
+        assert deserialized_error.halted_container == Failure('error')
+        assert deserialized_error.halted_container != Success('error')

--- a/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
+++ b/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
@@ -11,15 +11,10 @@ def test_pickle_unwrap_failed_error_from_maybe():
     try:
         Nothing.unwrap()  # This will raise UnwrapFailedError
     except UnwrapFailedError as error:
-        # Serialize the error
         serialized = pickle.dumps(error)
 
-    # Deserialize
     deserialized_error = pickle.loads(serialized)  # noqa: S301
-
-    # Check that halted_container is preserved
     assert deserialized_error.halted_container == Nothing
-    assert deserialized_error.halted_container != Some(None)
 
 
 def test_pickle_unwrap_failed_error_from_result():
@@ -28,11 +23,7 @@ def test_pickle_unwrap_failed_error_from_result():
     try:
         Failure('error').unwrap()  # This will raise UnwrapFailedError
     except UnwrapFailedError as error:
-        # Serialize the error
         serialized = pickle.dumps(error)
 
-    # Deserialize
     deserialized_error = pickle.loads(serialized)  # noqa: S301
-    # Check that halted_container is preserved
     assert deserialized_error.halted_container == Failure('error')
-    assert deserialized_error.halted_container != Success('error')

--- a/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
+++ b/tests/test_primitives/test_exceptions/test_pickle_unwrap_failed_error.py
@@ -9,15 +9,11 @@ def test_pickle_unwrap_failed_error_from_maybe():
     """Ensures that UnwrapFailedError with Maybe can be pickled."""
     error = None
     serialized = None
-    error = None
     try:
         Nothing.unwrap()  # This will raise UnwrapFailedError
     except UnwrapFailedError as error:
         # Serialize the error
         serialized = pickle.dumps(error)
-
-    assert error is not None
-    assert serialized is not None
 
     # Deserialize
     deserialized_error = pickle.loads(serialized)  # noqa: S301
@@ -31,15 +27,11 @@ def test_pickle_unwrap_failed_error_from_result():
     """Ensures that UnwrapFailedError with Result can be pickled."""
     error = None
     serialized = None
-    error = None
     try:
         Failure('error').unwrap()  # This will raise UnwrapFailedError
     except UnwrapFailedError as error:
         # Serialize the error
         serialized = pickle.dumps(error)
-
-    assert error is not None
-    assert serialized is not None
 
     # Deserialize
     deserialized_error = pickle.loads(serialized)  # noqa: S301


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues

Fixes #2048

## Description

This PR adds pickle support for `UnwrapFailedError` by implementing the `__reduce__` method.
This allows the exception to be serialized/deserialized while preserving the `halted_container` information when using it in multiprocessing or other scenarios requiring serialization.

## Changes

- Added `__reduce__` method to `UnwrapFailedError` class
- Added tests to verify pickling works with both `Maybe` and `Result` containers
- Updated CHANGELOG.md under Bugfixes section