### PR TITLE
Make the `hypothesis` plugin check laws from user-defined interfaces too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ See [0Ver](https://0ver.org/).
 
 ## 0.24.1
 
+### Features
+
+- Make `hypothesis` plugin test laws from user-defined interfaces too
+
 ### Bugfixes
 
 - Add pickling support for `UnwrapFailedError` exception

--- a/docs/pages/contrib/hypothesis_plugins.rst
+++ b/docs/pages/contrib/hypothesis_plugins.rst
@@ -81,9 +81,9 @@ It works in a combination with "Laws as Values" feature we provide in the core.
 
   check_all_laws(YourCustomContainer)
 
-This one line of code will generate ~100 tests for all defined law
+This one line of code will generate ~100 tests for all defined laws
 in both ``YourCustomContainer`` and all its super types,
-including our internal ones.
+including our internal ones and user-defined ones.
 
 We also provide a way to configure
 the checking process with ``settings_kwargs``:

--- a/returns/contrib/hypothesis/laws.py
+++ b/returns/contrib/hypothesis/laws.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
-from typing import Any, NamedTuple, TypeVar, final
+from typing import Any, NamedTuple, TypeGuard, TypeVar, final
 
 import pytest
 from hypothesis import given
@@ -219,11 +219,15 @@ def lawful_interfaces(container_type: type[Lawful]) -> set[type[object]]:
     return {
         base_type
         for base_type in container_type.__mro__
-        if (
-            getattr(base_type, '__module__', '').startswith('returns.')
-            and base_type not in {Lawful, container_type}
-        )
+        if _is_lawful_interface(base_type)
+        and base_type not in {Lawful, container_type}
     }
+
+
+def _is_lawful_interface(
+    interface_type: type[object],
+) -> TypeGuard[type[Lawful]]:
+    return issubclass(interface_type, Lawful)
 
 
 def _clean_caches() -> None:

--- a/returns/contrib/hypothesis/laws.py
+++ b/returns/contrib/hypothesis/laws.py
@@ -83,14 +83,7 @@ def container_strategies(
 
     Can be used independently from other functions.
     """
-    our_interfaces = {
-        base_type
-        for base_type in container_type.__mro__
-        if (
-            getattr(base_type, '__module__', '').startswith('returns.')
-            and base_type not in {Lawful, container_type}
-        )
-    }
+    our_interfaces = lawful_interfaces(container_type)
     for interface in our_interfaces:
         st.register_type_strategy(
             interface,
@@ -219,6 +212,18 @@ def clean_plugin_context() -> Iterator[None]:
     finally:
         for saved_state in saved_stategies.items():
             st.register_type_strategy(*saved_state)
+
+
+def lawful_interfaces(container_type: type[Lawful]) -> set[type[object]]:
+    """Return ancestors of `container_type` that are lawful interfaces."""
+    return {
+        base_type
+        for base_type in container_type.__mro__
+        if (
+            getattr(base_type, '__module__', '').startswith('returns.')
+            and base_type not in {Lawful, container_type}
+        )
+    }
 
 
 def _clean_caches() -> None:

--- a/returns/contrib/hypothesis/laws.py
+++ b/returns/contrib/hypothesis/laws.py
@@ -10,7 +10,7 @@ from hypothesis import strategies as st
 from hypothesis.strategies._internal import types  # noqa: PLC2701
 
 from returns.contrib.hypothesis.containers import strategy_from_container
-from returns.primitives.laws import Law, Lawful
+from returns.primitives.laws import LAWS_ATTRIBUTE, Law, Lawful
 
 
 @final
@@ -214,7 +214,7 @@ def clean_plugin_context() -> Iterator[None]:
             st.register_type_strategy(*saved_state)
 
 
-def lawful_interfaces(container_type: type[Lawful]) -> set[type[object]]:
+def lawful_interfaces(container_type: type[Lawful]) -> set[type[Lawful]]:
     """Return ancestors of `container_type` that are lawful interfaces."""
     return {
         base_type
@@ -227,7 +227,13 @@ def lawful_interfaces(container_type: type[Lawful]) -> set[type[object]]:
 def _is_lawful_interface(
     interface_type: type[object],
 ) -> TypeGuard[type[Lawful]]:
-    return issubclass(interface_type, Lawful)
+    return issubclass(interface_type, Lawful) and _has_non_inherited_attribute(
+        interface_type, LAWS_ATTRIBUTE
+    )
+
+
+def _has_non_inherited_attribute(type_: type[object], attribute: str) -> bool:
+    return attribute in type_.__dict__
 
 
 def _clean_caches() -> None:

--- a/returns/primitives/laws.py
+++ b/returns/primitives/laws.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import ClassVar, Generic, TypeVar, final
+from typing import ClassVar, Final, Generic, TypeVar, final
 
 from returns.primitives.types import Immutable
 
@@ -12,7 +12,7 @@ _TypeArgType3 = TypeVar('_TypeArgType3')
 #: Special alias to define laws as functions even inside a class
 law_definition = staticmethod
 
-LAWS_ATTRIBUTE: str = '_laws'
+LAWS_ATTRIBUTE: Final = '_laws'
 
 
 class Law(Immutable):

--- a/returns/primitives/laws.py
+++ b/returns/primitives/laws.py
@@ -12,6 +12,8 @@ _TypeArgType3 = TypeVar('_TypeArgType3')
 #: Special alias to define laws as functions even inside a class
 law_definition = staticmethod
 
+LAWS_ATTRIBUTE: str = '_laws'
+
 
 class Law(Immutable):
     """
@@ -132,7 +134,7 @@ class Lawful(Generic[_Caps]):
 
         laws = {}
         for klass in seen.values():
-            current_laws = klass.__dict__.get('_laws', ())
+            current_laws = klass.__dict__.get(LAWS_ATTRIBUTE, ())
             if not current_laws:
                 continue
             laws[klass] = current_laws

--- a/tests/test_contrib/test_hypothesis/test_interface_resolution.py
+++ b/tests/test_contrib/test_hypothesis/test_interface_resolution.py
@@ -15,22 +15,15 @@ def test_lawful_interfaces__container_defined_in_returns() -> None:
         "<class 'returns.interfaces.altable.AltableN'>",
         "<class 'returns.interfaces.applicative.ApplicativeN'>",
         "<class 'returns.interfaces.bimappable.BiMappableN'>",
-        "<class 'returns.interfaces.bindable.BindableN'>",
         "<class 'returns.interfaces.container.ContainerN'>",
         "<class 'returns.interfaces.equable.Equable'>",
         "<class 'returns.interfaces.failable.DiverseFailableN'>",
         "<class 'returns.interfaces.failable.FailableN'>",
-        "<class 'returns.interfaces.lashable.LashableN'>",
         "<class 'returns.interfaces.mappable.MappableN'>",
         "<class 'returns.interfaces.specific.result.ResultBasedN'>",
         "<class 'returns.interfaces.specific.result.ResultLikeN'>",
         "<class 'returns.interfaces.specific.result.UnwrappableResult'>",
         "<class 'returns.interfaces.swappable.SwappableN'>",
-        "<class 'returns.interfaces.unwrappable.Unwrappable'>",
-        "<class 'returns.primitives.container.BaseContainer'>",
-        "<class 'returns.primitives.hkt.KindN'>",
-        "<class 'returns.primitives.hkt.SupportsKindN'>",
-        "<class 'returns.primitives.types.Immutable'>",
     ]
 
 
@@ -41,10 +34,6 @@ def test_lawful_interfaces__container_defined_outside_returns() -> None:
     assert sorted(str(interface) for interface in result) == [
         "<class 'returns.interfaces.applicative.ApplicativeN'>",
         "<class 'returns.interfaces.mappable.MappableN'>",
-        "<class 'returns.primitives.container.BaseContainer'>",
-        "<class 'returns.primitives.hkt.KindN'>",
-        "<class 'returns.primitives.hkt.SupportsKindN'>",
-        "<class 'returns.primitives.types.Immutable'>",
     ]
 
 
@@ -52,10 +41,7 @@ def test_lawful_interfaces__interface_defined_outside_returns() -> None:
     """Check container with interface defined outside `returns`."""
     result = lawful_interfaces(test_custom_interface_with_laws._Wrapper)  # noqa: SLF001
 
-    # NOTE: The interface `_MappableN` is missing.
     assert sorted(str(interface) for interface in result) == [
-        "<class 'returns.primitives.container.BaseContainer'>",
-        "<class 'returns.primitives.hkt.KindN'>",
-        "<class 'returns.primitives.hkt.SupportsKindN'>",
-        "<class 'returns.primitives.types.Immutable'>",
+        "<class 'test_hypothesis.test_laws.test_custom_interface_with_laws"
+        "._MappableN'>"
     ]

--- a/tests/test_contrib/test_hypothesis/test_interface_resolution.py
+++ b/tests/test_contrib/test_hypothesis/test_interface_resolution.py
@@ -14,15 +14,11 @@ def test_lawful_interfaces__container_defined_in_returns() -> None:
     assert sorted(str(interface) for interface in result) == [
         "<class 'returns.interfaces.altable.AltableN'>",
         "<class 'returns.interfaces.applicative.ApplicativeN'>",
-        "<class 'returns.interfaces.bimappable.BiMappableN'>",
         "<class 'returns.interfaces.container.ContainerN'>",
         "<class 'returns.interfaces.equable.Equable'>",
         "<class 'returns.interfaces.failable.DiverseFailableN'>",
         "<class 'returns.interfaces.failable.FailableN'>",
         "<class 'returns.interfaces.mappable.MappableN'>",
-        "<class 'returns.interfaces.specific.result.ResultBasedN'>",
-        "<class 'returns.interfaces.specific.result.ResultLikeN'>",
-        "<class 'returns.interfaces.specific.result.UnwrappableResult'>",
         "<class 'returns.interfaces.swappable.SwappableN'>",
     ]
 

--- a/tests/test_contrib/test_hypothesis/test_interface_resolution.py
+++ b/tests/test_contrib/test_hypothesis/test_interface_resolution.py
@@ -1,0 +1,61 @@
+from returns.contrib.hypothesis.laws import lawful_interfaces
+from returns.result import Result
+
+from .test_laws import (
+    test_custom_interface_with_laws,
+    test_custom_type_applicative,
+)
+
+
+def test_lawful_interfaces__container_defined_in_returns() -> None:
+    """Check that it returns all interfaces for a container in `returns`."""
+    result = lawful_interfaces(Result)
+
+    assert sorted(str(interface) for interface in result) == [
+        "<class 'returns.interfaces.altable.AltableN'>",
+        "<class 'returns.interfaces.applicative.ApplicativeN'>",
+        "<class 'returns.interfaces.bimappable.BiMappableN'>",
+        "<class 'returns.interfaces.bindable.BindableN'>",
+        "<class 'returns.interfaces.container.ContainerN'>",
+        "<class 'returns.interfaces.equable.Equable'>",
+        "<class 'returns.interfaces.failable.DiverseFailableN'>",
+        "<class 'returns.interfaces.failable.FailableN'>",
+        "<class 'returns.interfaces.lashable.LashableN'>",
+        "<class 'returns.interfaces.mappable.MappableN'>",
+        "<class 'returns.interfaces.specific.result.ResultBasedN'>",
+        "<class 'returns.interfaces.specific.result.ResultLikeN'>",
+        "<class 'returns.interfaces.specific.result.UnwrappableResult'>",
+        "<class 'returns.interfaces.swappable.SwappableN'>",
+        "<class 'returns.interfaces.unwrappable.Unwrappable'>",
+        "<class 'returns.primitives.container.BaseContainer'>",
+        "<class 'returns.primitives.hkt.KindN'>",
+        "<class 'returns.primitives.hkt.SupportsKindN'>",
+        "<class 'returns.primitives.types.Immutable'>",
+    ]
+
+
+def test_lawful_interfaces__container_defined_outside_returns() -> None:
+    """Check container defined outside `returns`."""
+    result = lawful_interfaces(test_custom_type_applicative._Wrapper)  # noqa: SLF001
+
+    assert sorted(str(interface) for interface in result) == [
+        "<class 'returns.interfaces.applicative.ApplicativeN'>",
+        "<class 'returns.interfaces.mappable.MappableN'>",
+        "<class 'returns.primitives.container.BaseContainer'>",
+        "<class 'returns.primitives.hkt.KindN'>",
+        "<class 'returns.primitives.hkt.SupportsKindN'>",
+        "<class 'returns.primitives.types.Immutable'>",
+    ]
+
+
+def test_lawful_interfaces__interface_defined_outside_returns() -> None:
+    """Check container with interface defined outside `returns`."""
+    result = lawful_interfaces(test_custom_interface_with_laws._Wrapper)  # noqa: SLF001
+
+    # NOTE: The interface `_MappableN` is missing.
+    assert sorted(str(interface) for interface in result) == [
+        "<class 'returns.primitives.container.BaseContainer'>",
+        "<class 'returns.primitives.hkt.KindN'>",
+        "<class 'returns.primitives.hkt.SupportsKindN'>",
+        "<class 'returns.primitives.types.Immutable'>",
+    ]

--- a/tests/test_contrib/test_hypothesis/test_interface_resolution.py
+++ b/tests/test_contrib/test_hypothesis/test_interface_resolution.py
@@ -1,13 +1,12 @@
 from returns.contrib.hypothesis.laws import lawful_interfaces
 from returns.result import Result
-
-from .test_laws import (
+from test_hypothesis.test_laws import (
     test_custom_interface_with_laws,
     test_custom_type_applicative,
 )
 
 
-def test_lawful_interfaces__container_defined_in_returns() -> None:
+def test_container_defined_in_returns() -> None:
     """Check that it returns all interfaces for a container in `returns`."""
     result = lawful_interfaces(Result)
 
@@ -23,7 +22,7 @@ def test_lawful_interfaces__container_defined_in_returns() -> None:
     ]
 
 
-def test_lawful_interfaces__container_defined_outside_returns() -> None:
+def test_container_defined_outside_returns() -> None:
     """Check container defined outside `returns`."""
     result = lawful_interfaces(test_custom_type_applicative._Wrapper)  # noqa: SLF001
 
@@ -33,7 +32,7 @@ def test_lawful_interfaces__container_defined_outside_returns() -> None:
     ]
 
 
-def test_lawful_interfaces__interface_defined_outside_returns() -> None:
+def test_interface_defined_outside_returns() -> None:
     """Check container with interface defined outside `returns`."""
     result = lawful_interfaces(test_custom_interface_with_laws._Wrapper)  # noqa: SLF001
 

--- a/tests/test_contrib/test_hypothesis/test_laws/test_custom_interface_with_laws.py
+++ b/tests/test_contrib/test_hypothesis/test_laws/test_custom_interface_with_laws.py
@@ -2,8 +2,6 @@ from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from typing import ClassVar, Generic, TypeAlias, TypeVar, final
 
-import pytest
-from hypothesis.errors import ResolutionFailed
 from typing_extensions import Never
 
 from returns.contrib.hypothesis.laws import check_all_laws
@@ -84,10 +82,14 @@ class _MappableN(
 _Mappable1: TypeAlias = _MappableN[_FirstType, Never, Never]
 
 
+class _ParentWrapper(_Mappable1[_ValueType]):
+    """Class that is an ancestor of `_Wrapper` but has no laws."""
+
+
 class _Wrapper(
     BaseContainer,
     SupportsKind1['_Wrapper', _ValueType],
-    _Mappable1[_ValueType],
+    _ParentWrapper[_ValueType],
 ):
     """Simple instance of `_MappableN`."""
 
@@ -103,6 +105,6 @@ class _Wrapper(
         return _Wrapper(function(self._inner_value))
 
 
-pytestmark = pytest.mark.xfail(raises=ResolutionFailed)
-
-check_all_laws(_Wrapper)
+# We need to use `use_init=True` because `MappableN` does not automatically
+# get a strategy from `strategy_from_container`.
+check_all_laws(_Wrapper, use_init=True)

--- a/tests/test_contrib/test_hypothesis/test_laws/test_custom_interface_with_laws.py
+++ b/tests/test_contrib/test_hypothesis/test_laws/test_custom_interface_with_laws.py
@@ -1,0 +1,108 @@
+from abc import abstractmethod
+from collections.abc import Callable, Sequence
+from typing import ClassVar, Generic, TypeAlias, TypeVar, final
+
+import pytest
+from hypothesis.errors import ResolutionFailed
+from typing_extensions import Never
+
+from returns.contrib.hypothesis.laws import check_all_laws
+from returns.functions import compose, identity
+from returns.primitives.asserts import assert_equal
+from returns.primitives.container import BaseContainer
+from returns.primitives.hkt import KindN, SupportsKind1
+from returns.primitives.laws import (
+    Law,
+    Law1,
+    Law3,
+    Lawful,
+    LawSpecDef,
+    law_definition,
+)
+
+_FirstType = TypeVar('_FirstType')
+_SecondType = TypeVar('_SecondType')
+_ThirdType = TypeVar('_ThirdType')
+_UpdatedType = TypeVar('_UpdatedType')
+
+_MappableType = TypeVar('_MappableType', bound='_MappableN')
+_ValueType = TypeVar('_ValueType')
+_NewValueType = TypeVar('_NewValueType')
+
+# Used in laws:
+_NewType1 = TypeVar('_NewType1')
+_NewType2 = TypeVar('_NewType2')
+
+
+@final
+class _LawSpec(LawSpecDef):
+    """Copy of the functor laws for `MappableN`."""
+
+    __slots__ = ()
+
+    @law_definition
+    def identity_law(
+        mappable: '_MappableN[_FirstType, _SecondType, _ThirdType]',
+    ) -> None:
+        """Mapping identity over a value must return the value unchanged."""
+        assert_equal(mappable.map(identity), mappable)
+
+    @law_definition
+    def associative_law(
+        mappable: '_MappableN[_FirstType, _SecondType, _ThirdType]',
+        first: Callable[[_FirstType], _NewType1],
+        second: Callable[[_NewType1], _NewType2],
+    ) -> None:
+        """Mapping twice or mapping a composition is the same thing."""
+        assert_equal(
+            mappable.map(first).map(second),
+            mappable.map(compose(first, second)),
+        )
+
+
+class _MappableN(
+    Lawful['_MappableN[_FirstType, _SecondType, _ThirdType]'],
+    Generic[_FirstType, _SecondType, _ThirdType],
+):
+    """Simple "user-defined" copy of `MappableN`."""
+
+    __slots__ = ()
+
+    _laws: ClassVar[Sequence[Law]] = (
+        Law1(_LawSpec.identity_law),
+        Law3(_LawSpec.associative_law),
+    )
+
+    @abstractmethod  # noqa: WPS125
+    def map(
+        self: _MappableType,
+        function: Callable[[_FirstType], _UpdatedType],
+    ) -> KindN[_MappableType, _UpdatedType, _SecondType, _ThirdType]:
+        """Allows to run a pure function over a container."""
+
+
+_Mappable1: TypeAlias = _MappableN[_FirstType, Never, Never]
+
+
+class _Wrapper(
+    BaseContainer,
+    SupportsKind1['_Wrapper', _ValueType],
+    _Mappable1[_ValueType],
+):
+    """Simple instance of `_MappableN`."""
+
+    _inner_value: _ValueType
+
+    def __init__(self, inner_value: _ValueType) -> None:
+        super().__init__(inner_value)
+
+    def map(
+        self,
+        function: Callable[[_ValueType], _NewValueType],
+    ) -> '_Wrapper[_NewValueType]':
+        return _Wrapper(function(self._inner_value))
+
+
+pytestmark = pytest.mark.xfail(raises=ResolutionFailed)
+
+check_all_laws(_Wrapper)


### PR DESCRIPTION
# I have made things!

Thanks for the thoughtful and convenient plugin for running interface laws.

I found, however, that the plugin was not running the laws for an interface I defined myself. So, I decided to add that behavior.

Main changes:

+ We run laws from ancestor classes outside the `returns` module. This is the user-visible change.
+ In the `hypothesis` plugin, for each property test, we patch the interface with the container strategy:
   - Earlier, we were patching all ancestor classes, regardless of whether they had any laws. (We can see that in a [test file before the fix](https://github.com/dry-python/returns/blob/f4cc763d3809e478382ec5834e388860a0cdaf83/tests/test_contrib/test_hypothesis/test_interface_resolution.py))
   - Now, we are being more precise and patching only classes that have laws. But there should be no user-visible change. It's just cleaner.

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the `CHANGELOG.md`

## Related issues