### PR TITLE
Add lock to ReAwaitable for concurrent awaits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ incremental in minor, bugfixes only are patches.
 See [0Ver](https://0ver.org/).
 
 
+## 0.25.1
+
+### Bugfixes
+
+- Adds lock to `ReAwaitable` to safely handle multiple concurrent awaits on the same instance
+
+
 ## 0.25.0
 
 ### Features

--- a/tests/test_primitives/test_reawaitable/test_reawaitable_concurrency.py
+++ b/tests/test_primitives/test_reawaitable/test_reawaitable_concurrency.py
@@ -1,0 +1,20 @@
+import anyio
+import pytest
+
+from returns.primitives.reawaitable import ReAwaitable
+
+
+async def sample_coro():
+    await anyio.sleep(0.1)
+    return "done"
+
+@pytest.mark.anyio
+async def test_concurrent_awaitable():
+    reawaitable = ReAwaitable(sample_coro())
+
+    async def await_reawaitable():
+        return await reawaitable
+    async with anyio.create_task_group() as tg:
+        task1 = tg.start_soon(await_reawaitable)
+        task2 = tg.start_soon(await_reawaitable)
+


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request
- [x] I have created a test case for the changes I have made (test_reawaitable_concurrency.py)
- [x] I have updated the documentation for the changes I have made
- [x] I have added my changes to the \

## Related issues

This PR addresses the issue where multiple concurrent awaits on the same ReAwaitable instance could lead to unexpected behavior. By adding a lock around the critical section in the _awaitable method, we ensure that the coroutine is only awaited once even when multiple tasks await the same ReAwaitable concurrently.

The PR includes a test case that demonstrates concurrent awaiting works correctly with the lock in place.

🙏 Please, if you or your company finds \ valuable, help us sustain the project by sponsoring it transparently on https://github.com/sponsors/dry-python.