### PR TITLE
Add the ability to add debugging notes to the result.safe decorator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ incremental in minor, bugfixes only are patches.
 See [0Ver](https://0ver.org/).
 
 
+### Features
+
+ - Add the ability to add debugging notes to the `safe` decorator.
+
+
 ## 0.25.0
 
 ### Features

--- a/returns/result.py
+++ b/returns/result.py
@@ -1,3 +1,4 @@
+import sys
 from abc import ABC
 from collections.abc import Callable, Generator, Iterator
 from functools import wraps
@@ -12,18 +13,18 @@ from returns.primitives.exceptions import UnwrapFailedError
 from returns.primitives.hkt import Kind2, SupportsKind2
 
 # Definitions:
-_ValueType_co = TypeVar('_ValueType_co', covariant=True)
-_NewValueType = TypeVar('_NewValueType')
-_ErrorType_co = TypeVar('_ErrorType_co', covariant=True)
-_NewErrorType = TypeVar('_NewErrorType')
+_ValueType_co = TypeVar("_ValueType_co", covariant=True)
+_NewValueType = TypeVar("_NewValueType")
+_ErrorType_co = TypeVar("_ErrorType_co", covariant=True)
+_NewErrorType = TypeVar("_NewErrorType")
 
-_FirstType = TypeVar('_FirstType')
-_FuncParams = ParamSpec('_FuncParams')
+_FirstType = TypeVar("_FirstType")
+_FuncParams = ParamSpec("_FuncParams")
 
 
 class Result(  # type: ignore[type-var]
     BaseContainer,
-    SupportsKind2['Result', _ValueType_co, _ErrorType_co],
+    SupportsKind2["Result", _ValueType_co, _ErrorType_co],
     result.ResultBased2[_ValueType_co, _ErrorType_co],
     ABC,
 ):
@@ -39,8 +40,8 @@ class Result(  # type: ignore[type-var]
 
     """
 
-    __slots__ = ('_trace',)
-    __match_args__ = ('_inner_value',)
+    __slots__ = ("_trace",)
+    __match_args__ = ("_inner_value",)
 
     _inner_value: _ValueType_co | _ErrorType_co
     _trace: list[FrameInfo] | None
@@ -53,7 +54,7 @@ class Result(  # type: ignore[type-var]
         """Returns a list with stack trace when :func:`~Failure` was called."""
         return self._trace
 
-    def swap(self) -> 'Result[_ErrorType_co, _ValueType_co]':
+    def swap(self) -> "Result[_ErrorType_co, _ValueType_co]":
         """
         Swaps value and error types.
 
@@ -73,7 +74,7 @@ class Result(  # type: ignore[type-var]
     def map(
         self,
         function: Callable[[_ValueType_co], _NewValueType],
-    ) -> 'Result[_NewValueType, _ErrorType_co]':
+    ) -> "Result[_NewValueType, _ErrorType_co]":
         """
         Composes successful container with a pure function.
 
@@ -92,11 +93,11 @@ class Result(  # type: ignore[type-var]
     def apply(
         self,
         container: Kind2[
-            'Result',
+            "Result",
             Callable[[_ValueType_co], _NewValueType],
             _ErrorType_co,
         ],
-    ) -> 'Result[_NewValueType, _ErrorType_co]':
+    ) -> "Result[_NewValueType, _ErrorType_co]":
         """
         Calls a wrapped function in a container on this container.
 
@@ -119,9 +120,9 @@ class Result(  # type: ignore[type-var]
         self,
         function: Callable[
             [_ValueType_co],
-            Kind2['Result', _NewValueType, _ErrorType_co],
+            Kind2["Result", _NewValueType, _ErrorType_co],
         ],
-    ) -> 'Result[_NewValueType, _ErrorType_co]':
+    ) -> "Result[_NewValueType, _ErrorType_co]":
         """
         Composes successful container with a function that returns a container.
 
@@ -146,7 +147,7 @@ class Result(  # type: ignore[type-var]
     def alt(
         self,
         function: Callable[[_ErrorType_co], _NewErrorType],
-    ) -> 'Result[_ValueType_co, _NewErrorType]':
+    ) -> "Result[_ValueType_co, _NewErrorType]":
         """
         Composes failed container with a pure function to modify failure.
 
@@ -166,9 +167,9 @@ class Result(  # type: ignore[type-var]
         self,
         function: Callable[
             [_ErrorType_co],
-            Kind2['Result', _ValueType_co, _NewErrorType],
+            Kind2["Result", _ValueType_co, _NewErrorType],
         ],
-    ) -> 'Result[_ValueType_co, _NewErrorType]':
+    ) -> "Result[_ValueType_co, _NewErrorType]":
         """
         Composes failed container with a function that returns a container.
 
@@ -195,7 +196,7 @@ class Result(  # type: ignore[type-var]
     def do(
         cls,
         expr: Generator[_NewValueType, None, None],
-    ) -> 'Result[_NewValueType, _NewErrorType]':
+    ) -> "Result[_NewValueType, _NewErrorType]":
         """
         Allows working with unwrapped values of containers in a safe way.
 
@@ -277,7 +278,7 @@ class Result(  # type: ignore[type-var]
     def from_value(
         cls,
         inner_value: _NewValueType,
-    ) -> 'Result[_NewValueType, Any]':
+    ) -> "Result[_NewValueType, Any]":
         """
         One more value to create success unit values.
 
@@ -298,7 +299,7 @@ class Result(  # type: ignore[type-var]
     def from_failure(
         cls,
         inner_value: _NewErrorType,
-    ) -> 'Result[Any, _NewErrorType]':
+    ) -> "Result[Any, _NewErrorType]":
         """
         One more value to create failure unit values.
 
@@ -318,8 +319,8 @@ class Result(  # type: ignore[type-var]
     @classmethod
     def from_result(
         cls,
-        inner_value: 'Result[_NewValueType, _NewErrorType]',
-    ) -> 'Result[_NewValueType, _NewErrorType]':
+        inner_value: "Result[_NewValueType, _NewErrorType]",
+    ) -> "Result[_NewValueType, _NewErrorType]":
         """
         Creates a new ``Result`` instance from existing ``Result`` instance.
 
@@ -350,7 +351,7 @@ class Failure(Result[Any, _ErrorType_co]):  # noqa: WPS338
     def __init__(self, inner_value: _ErrorType_co) -> None:
         """Failure constructor."""
         super().__init__(inner_value)
-        object.__setattr__(self, '_trace', self._get_trace())
+        object.__setattr__(self, "_trace", self._get_trace())
 
     if not TYPE_CHECKING:  # noqa: WPS604  # pragma: no branch
 
@@ -467,7 +468,7 @@ ResultE: TypeAlias = Result[_ValueType_co, Exception]
 
 # Decorators:
 
-_ExceptionType = TypeVar('_ExceptionType', bound=Exception)
+_ExceptionType = TypeVar("_ExceptionType", bound=Exception)
 
 
 @overload
@@ -480,16 +481,19 @@ def safe(
 @overload
 def safe(
     exceptions: tuple[type[_ExceptionType], ...],
+    add_note_on_failure: bool | str = False,
 ) -> Callable[
     [Callable[_FuncParams, _ValueType_co]],
     Callable[_FuncParams, Result[_ValueType_co, _ExceptionType]],
 ]: ...
 
 
+# add_note_on_failure is optional for backwards compatibility.
 def safe(  # noqa: WPS234
     exceptions: (
         Callable[_FuncParams, _ValueType_co] | tuple[type[_ExceptionType], ...]
     ),
+    add_note_on_failure: bool | str = False,
 ) -> (
     Callable[_FuncParams, ResultE[_ValueType_co]]
     | Callable[
@@ -534,6 +538,30 @@ def safe(  # noqa: WPS234
     In this case, only exceptions that are explicitly
     listed are going to be caught.
 
+    In order to add a note to the exception, you can use the
+    ``add_note_on_failure`` argument. It can be a string or a boolean value.
+    Either way, a generic note will be added to the exception that calls out
+    the file, line number, and function name where the error occured. If a
+    string is provided, it will be added as an additional note to the
+    exception.
+
+    This feature can help with logging and debugging.
+
+    Note that if you use this option, you must provide a tuple of exception
+    types as the first argument.
+
+    .. code:: python
+
+      >>> from returns.result import safe
+
+      >>> @safe((Exception,), add_note_on_failure=True)
+      ... def error_throwing_function() -> None:
+      ...     raise ValueError("This is an error!")
+
+      >>> @safe((Exception,), add_note_on_failure="A custom message")
+      ... def error_throwing_function() -> None:
+      ...     raise ValueError("This is an error!")
+
     Similar to :func:`returns.io.impure_safe`
     and :func:`returns.future.future_safe` decorators.
     """
@@ -550,6 +578,25 @@ def safe(  # noqa: WPS234
             try:
                 return Success(inner_function(*args, **kwargs))
             except inner_exceptions as exc:
+                if add_note_on_failure:
+                    # If the user provides a custom message, add it as a note
+                    # to the exception.  Otherwise just add a generic note.
+                    if isinstance(add_note_on_failure, str):
+                        exc.add_note(add_note_on_failure)
+
+                    # Add the generic note.
+                    exc_traceback = exc.__traceback__
+                    if exc_traceback is not None:
+                        filename = (
+                            exc_traceback.tb_next.tb_frame.f_code.co_filename
+                        )
+                        line_number = exc_traceback.tb_next.tb_lineno
+                        exc.add_note(
+                            f"Exception occurred in {inner_function.__name__} "
+                            f"of {filename} "
+                            f"at line number {line_number}."
+                        )
+
                 return Failure(exc)
 
         return decorator

--- a/tests/test_result/test_add_note_safe.py
+++ b/tests/test_result/test_add_note_safe.py
@@ -1,0 +1,45 @@
+from returns.result import safe
+from returns.pipeline import is_successful
+
+
+@safe((Exception,), add_note_on_failure=True)
+def error_throwing_function() -> None:
+    """Raises an exception."""
+    raise ValueError("This is an error!")
+
+
+@safe((Exception,), add_note_on_failure="A custom message")
+def error_throwing_function_with_message() -> None:
+    """Raises an exception."""
+    raise ValueError("This is an error!")
+
+
+def test_add_note_safe() -> None:
+    """Tests the add_note decorator with safe."""
+
+    result = error_throwing_function()
+
+    print(result)
+    print(result.failure().__notes__)
+    print(result.failure())
+    assert not is_successful(result)
+    assert (
+        "Exception occurred in error_throwing_function"
+        in result.failure().__notes__[0]
+    )
+
+
+def test_add_note_safe_with_message() -> None:
+    """Tests the add_note decorator with safe."""
+
+    result = error_throwing_function_with_message()
+
+    print(result)
+    print(result.failure().__notes__)
+    print(result.failure())
+    assert not is_successful(result)
+    assert "A custom message" in result.failure().__notes__
+    assert (
+        "Exception occurred in error_throwing_function_with_message"
+        in result.failure().__notes__[1]
+    )


### PR DESCRIPTION
# Add the ability to add debugging notes to the result.safe decorator.

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [X] I have updated the documentation for the changes I have made
- [X] I have added my changes to the `CHANGELOG.md`

## Related issues

-Refs #2107, but may not fully close it.  The need to provide a list of Exceptions in order to use the `add_note_on_failure` keyword is a little clunky.
number

Would appreciate any help with the overloading of the `safe` decorator to alleviate the need to provide a list of Exceptions.

I wasn't exactly sure how you wanted me to add the changes to the change log, so I just made a "Features" section at the top of the list that isn't attached to any version.  (I wasn't sure if you wanted me to go creating version numbers on your behalf or not).

Thanks for the great package!


🙏 Please, if you or your company finds `dry-python` valuable, help us sustain the project by sponsoring it transparently on https://github.com/sponsors/dry-python. As a thank you, your profile/company logo will be added to our main README which receives hundreds of unique visitors per day.
