### PR TITLE
fix: align future_safe non-specified exception test with safe/impure_safe siblings

### DIFF
--- a/tests/test_future/test_future_result/test_future_result_decorator.py
+++ b/tests/test_future/test_future_result/test_future_result_decorator.py
@@ -57,7 +57,7 @@ async def test_future_safe_decorator_w_expected_error(subtests):
 
 
 @pytest.mark.anyio
-@pytest.mark.xfail(raises=AssertionError)
 async def test_future_safe_decorator_w_unexpected_error():
-    """Ensure that coroutine marked with ``@future_safe``."""
-    await _coro_three('0')
+    """Ensure that @future_safe does not swallow non-specified exceptions."""
+    with pytest.raises(AssertionError):
+        await _coro_three('0')


### PR DESCRIPTION
## Problem

`test_future_safe_decorator_w_unexpected_error` is marked `@pytest.mark.xfail(raises=AssertionError)`. The test body calls `await _coro_three('0')` bare — `_coro_three` is decorated with `@future_safe((ZeroDivisionError,))`, so `AssertionError` (from the internal `assert isinstance(arg, int)`) correctly propagates rather than being caught. Because there is no `pytest.raises` to catch it, the test body raises and the test "fails" as xfail.

The library behaviour is **correct** — non-specified exceptions should propagate. The test was simply written incorrectly.

## Fix

Both sibling decorators already cover this case properly with `pytest.raises`:

- `test_safe_failure_with_non_expected_error` in `test_result_functions/test_safe.py`
- `test_safe_failure_with_non_expected_error` in `test_ioresult_functions/test_impure_safe.py`

Bring `future_safe` in line: wrap `await _coro_three('0')` in `pytest.raises(AssertionError)` and remove the `xfail` marker. No library code is changed.

## Before / After

**Before:** 2 xfailed (`asyncio` + `trio` backends)  
**After:** 8 passed, 0 xfailed

---

This pull request was prepared with the assistance of AI, under my direction and review.