### PR TITLE
Relax future() and future_safe() argument types from Coroutine to Awaitable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ incremental in minor, bugfixes only are patches.
 See [0Ver](https://0ver.org/).
 
 
+## 0.29.1 WIP
+
+### Bugfixes
+
+- Relaxes `future` and `future_safe` decorator argument types from
+  `Coroutine` to `Awaitable`, so plain `async def` functions wrapping
+  another awaitable (instead of being coroutine functions themselves)
+  type-check correctly
+
+
 ## 0.29.0
 
 ### Features

--- a/returns/future.py
+++ b/returns/future.py
@@ -37,7 +37,6 @@ _FuncParams = ParamSpec('_FuncParams')
 
 # Aliases:
 _FirstType = TypeVar('_FirstType')
-_SecondType = TypeVar('_SecondType')
 
 
 # Public composition helpers:
@@ -471,10 +470,7 @@ class Future(  # type: ignore[type-var]
 
 
 def future(
-    function: Callable[
-        _FuncParams,
-        Coroutine[_FirstType, _SecondType, _ValueType_co],
-    ],
+    function: Callable[_FuncParams, Awaitable[_ValueType_co]],
 ) -> Callable[_FuncParams, Future[_ValueType_co]]:
     """
     Decorator to turn a coroutine definition into ``Future`` container.
@@ -1526,10 +1522,7 @@ _ExceptionType = TypeVar('_ExceptionType', bound=Exception)
 
 @overload
 def future_safe(
-    exceptions: Callable[
-        _FuncParams,
-        Coroutine[_FirstType, _SecondType, _ValueType_co],
-    ],
+    exceptions: Callable[_FuncParams, Awaitable[_ValueType_co]],
     /,
 ) -> Callable[_FuncParams, FutureResultE[_ValueType_co]]: ...
 
@@ -1538,33 +1531,20 @@ def future_safe(
 def future_safe(
     exceptions: tuple[type[_ExceptionType], ...],
 ) -> Callable[
-    [
-        Callable[
-            _FuncParams,
-            Coroutine[_FirstType, _SecondType, _ValueType_co],
-        ],
-    ],
+    [Callable[_FuncParams, Awaitable[_ValueType_co]]],
     Callable[_FuncParams, FutureResult[_ValueType_co, _ExceptionType]],
 ]: ...
 
 
 def future_safe(  # noqa: WPS212, WPS234,
     exceptions: (
-        Callable[
-            _FuncParams,
-            Coroutine[_FirstType, _SecondType, _ValueType_co],
-        ]
+        Callable[_FuncParams, Awaitable[_ValueType_co]]
         | tuple[type[_ExceptionType], ...]
     ),
 ) -> (
     Callable[_FuncParams, FutureResultE[_ValueType_co]]
     | Callable[
-        [
-            Callable[
-                _FuncParams,
-                Coroutine[_FirstType, _SecondType, _ValueType_co],
-            ],
-        ],
+        [Callable[_FuncParams, Awaitable[_ValueType_co]]],
         Callable[_FuncParams, FutureResult[_ValueType_co, _ExceptionType]],
     ]
 ):
@@ -1621,10 +1601,7 @@ def future_safe(  # noqa: WPS212, WPS234,
     """
 
     def _future_safe_factory(  # noqa: WPS430
-        function: Callable[
-            _FuncParams,
-            Coroutine[_FirstType, _SecondType, _ValueType_co],
-        ],
+        function: Callable[_FuncParams, Awaitable[_ValueType_co]],
         inner_exceptions: tuple[type[_ExceptionType], ...],
     ) -> Callable[_FuncParams, FutureResult[_ValueType_co, _ExceptionType]]:
         async def factory(

--- a/typesafety/test_future/test_future_container/test_future_decorator.yml
+++ b/typesafety/test_future/test_future_container/test_future_decorator.yml
@@ -22,3 +22,18 @@
         ...
 
     reveal_type(future(test))  # N: Revealed type is "def (first: int) -> returns.future.Future[str]"
+
+
+- case: future_decorator_with_awaitable_type
+  disable_cache: false
+  main: |
+    from typing import Awaitable, Callable
+    from returns.future import future
+
+    async def test(first: int) -> int:
+        return first
+
+    # `future` should accept plain `Awaitable`, not just `Coroutine`.
+    typed_test: Callable[[int], Awaitable[int]] = test
+
+    reveal_type(future(typed_test))  # N: Revealed type is "def (int) -> returns.future.Future[int]"

--- a/typesafety/test_future/test_future_result_container/test_future_safe_decorator.yml
+++ b/typesafety/test_future/test_future_result_container/test_future_safe_decorator.yml
@@ -55,3 +55,19 @@
         return 1
 
     reveal_type(test)  # N: Revealed type is "def (first: int, second: str | None =, *, kw: bool =) -> returns.future.FutureResult[int, ValueError]"
+
+
+- case: future_safe_decorator_with_awaitable_type
+  disable_cache: false
+  main: |
+    from typing import Awaitable, Callable
+    from returns.future import future_safe
+
+    async def test(first: int) -> int:
+        return first
+
+    # `future_safe` should accept plain `Awaitable`, not just `Coroutine`.
+    typed_test: Callable[[int], Awaitable[int]] = test
+
+    reveal_type(future_safe(typed_test))  # N: Revealed type is "def (int) -> returns.future.FutureResult[int, Exception]"
+    reveal_type(future_safe((ValueError,))(typed_test))  # N: Revealed type is "def (int) -> returns.future.FutureResult[int, ValueError]"


### PR DESCRIPTION
# I have made things!

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [x] I have added my changes to the CHANGELOG.md

## Related issues

Closes #2404

## What changed

`future()` and `future_safe()` typed their wrapped function argument as returning `Coroutine`, which is stricter than needed. A callable typed as `Callable[..., Awaitable[T]]` (for example an `async def` that awaits and returns some other awaitable, rather than one whose own return is annotated `Coroutine`) failed type checking even though the decorators only ever `await` the result at runtime.

This widens the parameter type on both decorators (and the internal `_future_safe_factory` helper) to `Awaitable`, and removes the now unused `_SecondType` TypeVar that only existed to parameterize `Coroutine`.

## Test plan

- Added a typesafety case to `test_future_decorator.yml` and `test_future_safe_decorator.yml` covering a `Callable[[int], Awaitable[int]]` argument that is not itself typed as `Coroutine`.
- `pytest typesafety/test_future` (53 passed)
- `pytest tests -k future` (133 passed)
- `mypy returns` (no issues)
- `ruff check returns/future.py typesafety/test_future` (all checks passed)