### PR TITLE
Stop asserting the full Hypothesis strategy repr

### DIFF
--- a/tests/test_contrib/test_hypothesis/test_type_resolution.py
+++ b/tests/test_contrib/test_hypothesis/test_type_resolution.py
@@ -189,38 +189,36 @@ def test_types_to_strategies_default() -> None:  # noqa: WPS210
         default_settings(container_type),
     )
 
-    wrapper_strategy = (
-        'builds(from_value, shared(sampled_from([NoneType,'
-        ' bool, int, float, str,'
-        " bytes]), key='typevar=~_FirstType').flatmap(from_type))"
-    )
-    assert (
-        _strategy_string(result[container_type], container_type)
-        == wrapper_strategy
-    )
-    assert _strategy_strings(
+    wrapper_strategy = _strategy_string(result[container_type], container_type)
+    assert 'builds' in wrapper_strategy
+    assert 'from_value' in wrapper_strategy
+    assert 'sampled_from' in wrapper_strategy
+    assert 'from_type' in wrapper_strategy
+
+    interface_reprs = _strategy_strings(
         [result[interface] for interface in container_type.laws()],
         container_type,
-    ) == [
-        wrapper_strategy,
-        wrapper_strategy,
-    ]
-    assert (
-        _strategy_string(result[callable_type], Callable[[int, str], bool])
-        == 'functions(like=lambda *args, **kwargs: None,'
-        ' returns=booleans(), pure=True)'
     )
-    assert (
-        _strategy_string(result[callable_type], Callable[[], None])
-        == 'functions(like=lambda: None, returns=none(), pure=True)'
+    assert all('builds' in item for item in interface_reprs)
+    assert all('from_value' in item for item in interface_reprs)
+
+    functions_with_args = _strategy_string(
+        result[callable_type],
+        Callable[[int, str], bool],
     )
-    assert (
-        _strategy_string(result[TypeVar], _ValueType)
-        == 'shared(sampled_from([NoneType, bool,'
-        ' int, float, str, bytes]),'
-        " key='typevar=~_ValueType').flatmap(from_type).filter(lambda"
-        ' inner: inner == inner)'
+    assert 'functions' in functions_with_args
+    assert 'booleans' in functions_with_args
+
+    functions_no_args = _strategy_string(
+        result[callable_type],
+        Callable[[], None],
     )
+    assert 'functions' in functions_no_args
+    assert 'none' in functions_no_args
+
+    typevar_strategy = _strategy_string(result[TypeVar], _ValueType)
+    assert 'sampled_from' in typevar_strategy
+    assert 'from_type' in typevar_strategy
 
 
 def test_types_to_strategies_overrides() -> None:  # noqa: WPS210
@@ -247,27 +245,34 @@ def test_types_to_strategies_overrides() -> None:  # noqa: WPS210
         ),
     )
 
-    wrapper_strategy = 'builds(_Wrapper, integers())'
-    assert (
-        _strategy_string(result[container_type], container_type)
-        == wrapper_strategy
-    )
-    assert _strategy_strings(
+    wrapper_strategy = _strategy_string(result[container_type], container_type)
+    assert 'builds' in wrapper_strategy
+    assert '_Wrapper' in wrapper_strategy
+    assert 'integers' in wrapper_strategy
+
+    interface_reprs = _strategy_strings(
         [result[interface] for interface in container_type.laws()],
         container_type,
-    ) == [
-        wrapper_strategy,
-        wrapper_strategy,
-    ]
-    assert (
-        _strategy_string(result[callable_type], Callable[[int, str], bool])
-        == 'functions(returns=booleans())'
     )
-    assert (
-        _strategy_string(result[callable_type], Callable[[], None])
-        == 'functions(returns=booleans())'
+    assert all('builds' in item for item in interface_reprs)
+    assert all('_Wrapper' in item for item in interface_reprs)
+    assert all('integers' in item for item in interface_reprs)
+
+    functions_with_args = _strategy_string(
+        result[callable_type],
+        Callable[[int, str], bool],
     )
-    assert _strategy_string(result[TypeVar], _ValueType) == 'text()'
+    assert 'functions' in functions_with_args
+    assert 'booleans' in functions_with_args
+
+    functions_no_args = _strategy_string(
+        result[callable_type],
+        Callable[[], None],
+    )
+    assert 'functions' in functions_no_args
+    assert 'booleans' in functions_no_args
+
+    assert 'text' in _strategy_string(result[TypeVar], _ValueType)
 
 
 def _interface_factories(type_: type[Lawful]) -> list[StrategyFactory | None]:

--- a/tests/test_contrib/test_hypothesis/test_type_resolution.py
+++ b/tests/test_contrib/test_hypothesis/test_type_resolution.py
@@ -199,8 +199,10 @@ def test_types_to_strategies_default() -> None:  # noqa: WPS210
         [result[interface] for interface in container_type.laws()],
         container_type,
     )
-    assert all('builds' in item for item in interface_reprs)
-    assert all('from_value' in item for item in interface_reprs)
+    assert all('builds' in interface_repr for interface_repr in interface_reprs)
+    assert all(
+        'from_value' in interface_repr for interface_repr in interface_reprs
+    )
 
     functions_with_args = _strategy_string(
         result[callable_type],
@@ -254,9 +256,13 @@ def test_types_to_strategies_overrides() -> None:  # noqa: WPS210
         [result[interface] for interface in container_type.laws()],
         container_type,
     )
-    assert all('builds' in item for item in interface_reprs)
-    assert all('_Wrapper' in item for item in interface_reprs)
-    assert all('integers' in item for item in interface_reprs)
+    assert all('builds' in interface_repr for interface_repr in interface_reprs)
+    assert all(
+        '_Wrapper' in interface_repr for interface_repr in interface_reprs
+    )
+    assert all(
+        'integers' in interface_repr for interface_repr in interface_reprs
+    )
 
     functions_with_args = _strategy_string(
         result[callable_type],

--- a/tests/test_contrib/test_hypothesis/test_type_resolver.py
+++ b/tests/test_contrib/test_hypothesis/test_type_resolver.py
@@ -35,8 +35,12 @@ def test_types_without_strategies() -> None:  # noqa: WPS210
 
     assert strategy_before1 is None
     assert strategy_before2 is None
-    assert str(strategy_inside1) == 'builds(_Wrapper1, integers())'
-    assert str(strategy_inside2) == 'builds(_Wrapper2, text())'
+    assert 'builds' in str(strategy_inside1)
+    assert '_Wrapper1' in str(strategy_inside1)
+    assert 'integers' in str(strategy_inside1)
+    assert 'builds' in str(strategy_inside2)
+    assert '_Wrapper2' in str(strategy_inside2)
+    assert 'text' in str(strategy_inside2)
     assert strategy_after1 is None
     assert strategy_after2 is None
 
@@ -51,6 +55,12 @@ def test_type_with_strategy() -> None:
 
         strategy_after = look_up_strategy(_Wrapper1)
 
-    assert str(strategy_before) == 'builds(_Wrapper1, integers())'
-    assert str(strategy_inside) == 'builds(_Wrapper1, text())'
-    assert str(strategy_after) == 'builds(_Wrapper1, integers())'
+    assert 'builds' in str(strategy_before)
+    assert '_Wrapper1' in str(strategy_before)
+    assert 'integers' in str(strategy_before)
+    assert 'builds' in str(strategy_inside)
+    assert '_Wrapper1' in str(strategy_inside)
+    assert 'text' in str(strategy_inside)
+    assert 'builds' in str(strategy_after)
+    assert '_Wrapper1' in str(strategy_after)
+    assert 'integers' in str(strategy_after)


### PR DESCRIPTION
## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [x] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #2224

Hypothesis sometimes changes how strategies render (`str(strategy)`), which makes exact-equality checks fail across version bumps (see #2223).

These tests now check that the expected strategy names appear in the repr, instead of comparing the entire string. No library code changed.